### PR TITLE
docs: rebuild with updated documentation

### DIFF
--- a/build/adapters.html
+++ b/build/adapters.html
@@ -93,7 +93,6 @@
 <span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> {
   executeSelect,
-  executeSelectSimple,
   executeInsert,
   executeUpdate,
   executeDelete,
@@ -108,22 +107,26 @@
 <span class="hljs-keyword">const</span> db = <span class="hljs-title function_">pgp</span>(<span class="hljs-string">&quot;postgresql://user:pass@localhost:5432/mydb&quot;</span>);
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-comment">// Execute without external params</span>
-<span class="hljs-keyword">const</span> activeUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelectSimple</span>(db, schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-  q
-    .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
-    .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span>)
-    .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
+<span class="hljs-comment">// Execute with params</span>
+<span class="hljs-keyword">const</span> activeUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
+  db,
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+    q
+      .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
+      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span> &amp;&amp; u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
+      .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
+  { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 
 <span class="hljs-comment">// Execute with params</span>
 <span class="hljs-keyword">const</span> matchingUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q, p</span>) =&gt;</span>
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
-      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= p.<span class="hljs-property">minAge</span>)
+      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">21</span> },
 );
@@ -241,7 +244,7 @@ db.<span class="hljs-title function_">exec</span>(<span class="hljs-string">`
 <span class="hljs-keyword">const</span> removed = <span class="hljs-title function_">executeDelete</span>(
   db,
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q, p</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt; p.<span class="hljs-property">cutoff</span>),
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt; params.<span class="hljs-property">cutoff</span>),
   { <span class="hljs-attr">cutoff</span>: <span class="hljs-number">18</span> },
 );
 

--- a/build/api-reference.html
+++ b/build/api-reference.html
@@ -64,12 +64,11 @@
 <ul>
 <li><a href="#11-selectstatement">1.1 selectStatement</a></li>
 <li><a href="#12-executeselect">1.2 executeSelect</a></li>
-<li><a href="#13-executeselectsimple">1.3 executeSelectSimple</a></li>
-<li><a href="#14-insertstatement--executeinsert">1.4 insertStatement &amp; executeInsert</a></li>
-<li><a href="#15-updatestatement--executeupdate">1.5 updateStatement &amp; executeUpdate</a></li>
-<li><a href="#16-deletestatement--executedelete">1.6 deleteStatement &amp; executeDelete</a></li>
-<li><a href="#17-tosql">1.7 toSql</a></li>
-<li><a href="#18-executeoptions--sqlresult">1.8 ExecuteOptions &amp; SqlResult</a></li>
+<li><a href="#13-insertstatement--executeinsert">1.3 insertStatement &amp; executeInsert</a></li>
+<li><a href="#14-updatestatement--executeupdate">1.4 updateStatement &amp; executeUpdate</a></li>
+<li><a href="#15-deletestatement--executedelete">1.5 deleteStatement &amp; executeDelete</a></li>
+<li><a href="#16-tosql">1.6 toSql</a></li>
+<li><a href="#17-executeoptions--sqlresult">1.7 ExecuteOptions &amp; SqlResult</a></li>
 </ul>
 </li>
 <li><a href="#2-type-safe-contexts">2. Type-Safe Contexts</a>
@@ -111,10 +110,10 @@
 
 <span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">selectStatement</span>(
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q, p</span>) =&gt;</span>
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
-      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= p.<span class="hljs-property">minAge</span>)
+      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
@@ -156,51 +155,15 @@
 <span class="hljs-keyword">const</span> users = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q, p</span>) =&gt;</span>
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
-      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= p.<span class="hljs-property">minAge</span>)
+      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">21</span> },
 );
 </code></pre>
-<h3 id="13-executeselectsimple" tabindex="-1"><a class="anchor" href="#13-executeselectsimple" aria-hidden="true">#</a> 1.3 executeSelectSimple</h3>
-<p>Convenience wrapper for queries that do not need external parameters. The query builder receives a DSL context, an empty params object, and helper functions.</p>
-<pre class="hljs"><code><span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeSelectSimple&lt;
-  <span class="hljs-title class_">TSchema</span>,
-  <span class="hljs-title class_">TQuery</span> <span class="hljs-keyword">extends</span> <span class="hljs-title class_">Queryable</span>&lt;<span class="hljs-built_in">unknown</span>&gt; | <span class="hljs-title class_">OrderedQueryable</span>&lt;<span class="hljs-built_in">unknown</span>&gt; | <span class="hljs-title class_">TerminalQuery</span>&lt;<span class="hljs-built_in">unknown</span>&gt;,
-&gt;(
-  <span class="hljs-attr">db</span>: <span class="hljs-title class_">PgDatabase</span> | <span class="hljs-title class_">BetterSqlite3Database</span>,
-  <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-  <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
-    <span class="hljs-attr">ctx</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-    <span class="hljs-attr">params</span>: <span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">never</span>&gt;,
-    <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">QueryHelpers</span>,
-  </span>) =&gt;</span> <span class="hljs-title class_">TQuery</span>,
-  <span class="hljs-attr">options</span>?: <span class="hljs-title class_">ExecuteOptions</span>,
-): <span class="hljs-title class_">Promise</span>&lt;
-  <span class="hljs-title class_">TQuery</span> <span class="hljs-keyword">extends</span> <span class="hljs-title class_">Queryable</span>&lt;infer T&gt;
-    ? T[]
-    : <span class="hljs-title class_">TQuery</span> <span class="hljs-keyword">extends</span> <span class="hljs-title class_">OrderedQueryable</span>&lt;infer T&gt;
-      ? T[]
-      : <span class="hljs-title class_">TQuery</span> <span class="hljs-keyword">extends</span> <span class="hljs-title class_">TerminalQuery</span>&lt;infer T&gt;
-        ? T
-        : <span class="hljs-built_in">never</span>
-&gt;;
-</code></pre>
-<p><strong>Example</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeSelectSimple } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
-
-<span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
-  <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span> };
-}
-
-<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
-
-<span class="hljs-keyword">const</span> allUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelectSimple</span>(db, schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>));
-</code></pre>
-<h3 id="14-insertstatement-%26-executeinsert" tabindex="-1"><a class="anchor" href="#14-insertstatement-%26-executeinsert" aria-hidden="true">#</a> 1.4 insertStatement &amp; executeInsert</h3>
+<h3 id="13-insertstatement-%26-executeinsert" tabindex="-1"><a class="anchor" href="#13-insertstatement-%26-executeinsert" aria-hidden="true">#</a> 1.3 insertStatement &amp; executeInsert</h3>
 <p>Generate and execute INSERT statements with optional RETURNING clauses. The query builder receives a DSL context, parameters, and helper functions.</p>
 <pre class="hljs"><code><span class="hljs-keyword">function</span> insertStatement&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span> = <span class="hljs-built_in">never</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
@@ -264,7 +227,7 @@
   {},
 );
 </code></pre>
-<h3 id="15-updatestatement-%26-executeupdate" tabindex="-1"><a class="anchor" href="#15-updatestatement-%26-executeupdate" aria-hidden="true">#</a> 1.5 updateStatement &amp; executeUpdate</h3>
+<h3 id="14-updatestatement-%26-executeupdate" tabindex="-1"><a class="anchor" href="#14-updatestatement-%26-executeupdate" aria-hidden="true">#</a> 1.4 updateStatement &amp; executeUpdate</h3>
 <p>Generate and execute UPDATE statements with optional RETURNING clauses. The query builder receives a DSL context, parameters, and helper functions.</p>
 <pre class="hljs"><code><span class="hljs-keyword">function</span> updateStatement&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span> = <span class="hljs-built_in">never</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
@@ -316,15 +279,15 @@
 <span class="hljs-keyword">const</span> updatedRows = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeUpdate</span>(
   db,
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q, p</span>) =&gt;</span>
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> })
-      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">lastLogin</span> &lt; p.<span class="hljs-property">cutoff</span>),
+      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">lastLogin</span> &lt; params.<span class="hljs-property">cutoff</span>),
   { <span class="hljs-attr">cutoff</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>(<span class="hljs-string">&quot;2024-01-01&quot;</span>) },
 );
 </code></pre>
-<h3 id="16-deletestatement-%26-executedelete" tabindex="-1"><a class="anchor" href="#16-deletestatement-%26-executedelete" aria-hidden="true">#</a> 1.6 deleteStatement &amp; executeDelete</h3>
+<h3 id="15-deletestatement-%26-executedelete" tabindex="-1"><a class="anchor" href="#15-deletestatement-%26-executedelete" aria-hidden="true">#</a> 1.5 deleteStatement &amp; executeDelete</h3>
 <p>Generate and execute DELETE statements. The query builder receives a DSL context, parameters, and helper functions.</p>
 <pre class="hljs"><code><span class="hljs-keyword">function</span> deleteStatement&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TResult</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
@@ -365,7 +328,7 @@
   {},
 );
 </code></pre>
-<h3 id="17-statement-functions-(selectstatement%2C-insertstatement%2C-etc)" tabindex="-1"><a class="anchor" href="#17-statement-functions-(selectstatement%2C-insertstatement%2C-etc)" aria-hidden="true">#</a> 1.7 Statement Functions (selectStatement, insertStatement, etc.)</h3>
+<h3 id="16-statement-functions-(selectstatement%2C-insertstatement%2C-etc)" tabindex="-1"><a class="anchor" href="#16-statement-functions-(selectstatement%2C-insertstatement%2C-etc)" aria-hidden="true">#</a> 1.6 Statement Functions (selectStatement, insertStatement, etc.)</h3>
 <p>Generate SQL and parameters without executing them. These functions are useful for debugging, testing, or when you need the SQL before execution.</p>
 <pre class="hljs"><code><span class="hljs-keyword">function</span> selectStatement&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TResult</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
@@ -393,7 +356,7 @@
 <span class="hljs-comment">// result.sql contains the SQL string</span>
 <span class="hljs-comment">// result.params contains the parameters</span>
 </code></pre>
-<h3 id="18-executeoptions-%26-sqlresult" tabindex="-1"><a class="anchor" href="#18-executeoptions-%26-sqlresult" aria-hidden="true">#</a> 1.8 ExecuteOptions &amp; SqlResult</h3>
+<h3 id="17-executeoptions-%26-sqlresult" tabindex="-1"><a class="anchor" href="#17-executeoptions-%26-sqlresult" aria-hidden="true">#</a> 1.7 ExecuteOptions &amp; SqlResult</h3>
 <p>Both adapters expose <code>ExecuteOptions</code> and <code>SqlResult</code> for inspection and typing.</p>
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">ExecuteOptions</span> {
   <span class="hljs-attr">onSql</span>?: <span class="hljs-function">(<span class="hljs-params"><span class="hljs-attr">result</span>: <span class="hljs-title class_">SqlResult</span>&lt;<span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt;, <span class="hljs-built_in">unknown</span>&gt;</span>) =&gt;</span> <span class="hljs-built_in">void</span>;
@@ -471,12 +434,11 @@
   <li><a href="#1-execution-apis">1. Execution APIs</a></li>
   <li class="toc-sub"><a href="#11-selectstatement">1.1 selectStatement</a></li>
   <li class="toc-sub"><a href="#12-executeselect">1.2 executeSelect</a></li>
-  <li class="toc-sub"><a href="#13-executeselectsimple">1.3 executeSelectSimple</a></li>
-  <li class="toc-sub"><a href="#14-insertstatement-%26-executeinsert">1.4 insertStatement & executeInsert</a></li>
-  <li class="toc-sub"><a href="#15-updatestatement-%26-executeupdate">1.5 updateStatement & executeUpdate</a></li>
-  <li class="toc-sub"><a href="#16-deletestatement-%26-executedelete">1.6 deleteStatement & executeDelete</a></li>
-  <li class="toc-sub"><a href="#17-statement-functions-(selectstatement%2C-insertstatement%2C-etc)">1.7 Statement Functions (selectStatement, insertStatement, etc.)</a></li>
-  <li class="toc-sub"><a href="#18-executeoptions-%26-sqlresult">1.8 ExecuteOptions & SqlResult</a></li>
+  <li class="toc-sub"><a href="#13-insertstatement-%26-executeinsert">1.3 insertStatement & executeInsert</a></li>
+  <li class="toc-sub"><a href="#14-updatestatement-%26-executeupdate">1.4 updateStatement & executeUpdate</a></li>
+  <li class="toc-sub"><a href="#15-deletestatement-%26-executedelete">1.5 deleteStatement & executeDelete</a></li>
+  <li class="toc-sub"><a href="#16-statement-functions-(selectstatement%2C-insertstatement%2C-etc)">1.6 Statement Functions (selectStatement, insertStatement, etc.)</a></li>
+  <li class="toc-sub"><a href="#17-executeoptions-%26-sqlresult">1.7 ExecuteOptions & SqlResult</a></li>
   <li><a href="#2-type-safe-contexts">2. Type-Safe Contexts</a></li>
   <li class="toc-sub"><a href="#21-createschema">2.1 createSchema</a></li>
   <li><a href="#3-helper-utilities">3. Helper Utilities</a></li>

--- a/build/development.html
+++ b/build/development.html
@@ -244,7 +244,7 @@ npm <span class="hljs-built_in">test</span>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> { describe, it, beforeEach } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;mocha&quot;</span>;
 <span class="hljs-keyword">import</span> { strict <span class="hljs-keyword">as</span> assert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;assert&quot;</span>;
 <span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeSelectSimple } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 <span class="hljs-keyword">import</span> { db } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;./shared-db.js&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
@@ -256,11 +256,15 @@ npm <span class="hljs-built_in">test</span>
   });
 
   <span class="hljs-title function_">it</span>(<span class="hljs-string">&quot;should execute SELECT query&quot;</span>, <span class="hljs-title function_">async</span> () =&gt; {
-    <span class="hljs-keyword">const</span> results = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelectSimple</span>(db, schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-      q
-        .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
-        .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">25</span>)
-        .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
+    <span class="hljs-keyword">const</span> results = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
+      db,
+      schema,
+      <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+        q
+          .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
+          .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
+          .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
+      { <span class="hljs-attr">minAge</span>: <span class="hljs-number">25</span> },
     );
 
     assert.<span class="hljs-title function_">deepEqual</span>(results, [<span class="hljs-string">&quot;Alice&quot;</span>, <span class="hljs-string">&quot;Bob&quot;</span>]);
@@ -465,12 +469,12 @@ pgp.<span class="hljs-title function_">end</span>(); <span class="hljs-comment">
 <pre class="hljs"><code><span class="hljs-comment">// Incorrect - template literal in lambda</span>
 .<span class="hljs-title function_">where</span>(<span class="hljs-function"><span class="hljs-params">u</span> =&gt;</span> u.<span class="hljs-property">name</span> === <span class="hljs-string">`User <span class="hljs-subst">${userId}</span>`</span>)
 
-<span class="hljs-comment">// Correct - use params with executeSelectSimple</span>
-<span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelectSimple</span>(
+<span class="hljs-comment">// Correct - use params with executeSelect</span>
+<span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q, p</span>) =&gt;</span>
-    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span> === p.<span class="hljs-property">name</span>),
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span> === params.<span class="hljs-property">name</span>),
   { <span class="hljs-attr">name</span>: <span class="hljs-string">`User <span class="hljs-subst">${userId}</span>`</span> }
 );
 </code></pre>
@@ -482,12 +486,12 @@ pgp.<span class="hljs-title function_">end</span>(); <span class="hljs-comment">
 <span class="hljs-keyword">const</span> minAge = <span class="hljs-number">18</span>;
 .<span class="hljs-title function_">where</span>(<span class="hljs-function"><span class="hljs-params">u</span> =&gt;</span> u.<span class="hljs-property">age</span> &gt;= minAge)
 
-<span class="hljs-comment">// Correct - params pattern with executeSelectSimple</span>
-<span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelectSimple</span>(
+<span class="hljs-comment">// Correct - params pattern with executeSelect</span>
+<span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q, p</span>) =&gt;</span>
-    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= p.<span class="hljs-property">minAge</span>),
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> }
 );
 </code></pre>

--- a/build/guide.html
+++ b/build/guide.html
@@ -1367,10 +1367,10 @@
 <p>External variables must be passed via the params object - closure variables are not supported:</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">insertStatement</span>(
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q, p</span>) =&gt;</span>
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
     q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
-      <span class="hljs-attr">name</span>: p.<span class="hljs-property">name</span>,
-      <span class="hljs-attr">age</span>: p.<span class="hljs-property">age</span>,
+      <span class="hljs-attr">name</span>: params.<span class="hljs-property">name</span>,
+      <span class="hljs-attr">age</span>: params.<span class="hljs-property">age</span>,
       <span class="hljs-attr">email</span>: <span class="hljs-string">&quot;default@example.com&quot;</span>,
     }),
   { <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Bob&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">25</span> },
@@ -1450,10 +1450,10 @@
 <p>External variables must be passed via the params object:</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> updateStmt = <span class="hljs-title function_">updateStatement</span>(
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q, p</span>) =&gt;</span>
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
-      .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: p.<span class="hljs-property">newAge</span> })
+      .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: params.<span class="hljs-property">newAge</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">1</span>),
   { <span class="hljs-attr">newAge</span>: <span class="hljs-number">32</span> },
 );
@@ -1520,7 +1520,7 @@ Full table updates are dangerous and must be explicitly allowed.
 <h4 id="delete-with-in-clause" tabindex="-1"><a class="anchor" href="#delete-with-in-clause" aria-hidden="true">#</a> DELETE with IN Clause</h4>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> del = <span class="hljs-title function_">deleteStatement</span>(
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q, p</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> p.<span class="hljs-property">userIds</span>.<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">id</span>)),
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> params.<span class="hljs-property">userIds</span>.<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">id</span>)),
   { <span class="hljs-attr">userIds</span>: [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>] },
 );
 </code></pre>

--- a/build/index.html
+++ b/build/index.html
@@ -58,17 +58,20 @@
         <h1 id="tinqer" tabindex="-1"><a class="anchor" href="#tinqer" aria-hidden="true">#</a> Tinqer</h1>
 <p>Runtime LINQ-to-SQL query builder for TypeScript. Queries are expressed as inline arrow functions, parsed into an expression tree, and compiled into SQL for PostgreSQL or SQLite.</p>
 <h2 id="installation" tabindex="-1"><a class="anchor" href="#installation" aria-hidden="true">#</a> Installation</h2>
-<p>Install the adapter for your database:</p>
-<pre class="hljs"><code><span class="hljs-comment"># PostgreSQL (pg-promise)</span>
+<p>Install the core library and adapter for your database:</p>
+<pre class="hljs"><code><span class="hljs-comment"># Core library</span>
+npm install @webpods/tinqer
+
+<span class="hljs-comment"># PostgreSQL adapter (pg-promise)</span>
 npm install @webpods/tinqer-sql-pg-promise
 
-<span class="hljs-comment"># SQLite (better-sqlite3)</span>
+<span class="hljs-comment"># SQLite adapter (better-sqlite3)</span>
 npm install @webpods/tinqer-sql-better-sqlite3
 </code></pre>
 <h2 id="quick-start" tabindex="-1"><a class="anchor" href="#quick-start" aria-hidden="true">#</a> Quick Start</h2>
 <h3 id="postgresql-example" tabindex="-1"><a class="anchor" href="#postgresql-example" aria-hidden="true">#</a> PostgreSQL Example</h3>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeSelectSimple } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 <span class="hljs-keyword">import</span> pgPromise <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -84,49 +87,99 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <span class="hljs-keyword">const</span> db = <span class="hljs-title function_">pgp</span>(<span class="hljs-string">&quot;postgresql://user:pass@localhost:5432/mydb&quot;</span>);
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-keyword">const</span> results = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelectSimple</span>(db, schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-  q
-    .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
-    .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>)
-    .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>)
-    .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
+<span class="hljs-keyword">const</span> results = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
+  db,
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+    q
+      .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
+      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
+      .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>)
+      .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
+  { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 <span class="hljs-comment">// results: [{ id: 1, name: &quot;Alice&quot; }, { id: 2, name: &quot;Bob&quot; }]</span>
 </code></pre>
-<h3 id="sqlite-example" tabindex="-1"><a class="anchor" href="#sqlite-example" aria-hidden="true">#</a> SQLite Example</h3>
+<p><strong>The same query works with SQLite</strong> - just change the adapter and database connection:</p>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> <span class="hljs-title class_">Database</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;better-sqlite3&quot;</span>;
 <span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeSelect, selectStatement } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-better-sqlite3&quot;</span>;
+<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-better-sqlite3&quot;</span>;
 
+<span class="hljs-comment">// Same schema definition</span>
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
-  <span class="hljs-attr">products</span>: {
+  <span class="hljs-attr">users</span>: {
     <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>;
     <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>;
-    <span class="hljs-attr">price</span>: <span class="hljs-built_in">number</span>;
-    <span class="hljs-attr">inStock</span>: <span class="hljs-built_in">number</span>; <span class="hljs-comment">// SQLite uses INTEGER (0/1) for boolean values</span>
+    <span class="hljs-attr">email</span>: <span class="hljs-built_in">string</span>;
+    <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span>;
   };
 }
 
 <span class="hljs-keyword">const</span> db = <span class="hljs-keyword">new</span> <span class="hljs-title class_">Database</span>(<span class="hljs-string">&quot;./data.db&quot;</span>);
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
+<span class="hljs-comment">// Identical query logic</span>
 <span class="hljs-keyword">const</span> results = <span class="hljs-title function_">executeSelect</span>(
   db,
   schema,
   <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
     q
-      .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;products&quot;</span>)
-      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> p.<span class="hljs-property">inStock</span> === <span class="hljs-number">1</span> &amp;&amp; p.<span class="hljs-property">price</span> &lt; params.<span class="hljs-property">maxPrice</span>)
-      .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> p.<span class="hljs-property">price</span>),
-  { <span class="hljs-attr">maxPrice</span>: <span class="hljs-number">100</span> },
+      .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
+      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
+      .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>)
+      .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
+  { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
+<span class="hljs-comment">// results: [{ id: 1, name: &quot;Alice&quot; }, { id: 2, name: &quot;Bob&quot; }]</span>
+</code></pre>
+<h3 id="sql-generation-without-execution" tabindex="-1"><a class="anchor" href="#sql-generation-without-execution" aria-hidden="true">#</a> SQL Generation Without Execution</h3>
+<p><strong><code>execute*</code> functions</strong> execute queries and return results. <strong><code>*Statement</code> functions</strong> generate SQL and parameters without executing - useful for debugging, logging, or custom execution:</p>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> {
+  selectStatement,
+  insertStatement,
+  updateStatement,
+  deleteStatement,
+} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
-<span class="hljs-comment">// Need the raw SQL for logging or prepared statements? selectStatement is still available:</span>
-<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">selectStatement</span>(
+<span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
+  <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span> };
+}
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
+
+<span class="hljs-comment">// SELECT - returns { sql, params }</span>
+<span class="hljs-keyword">const</span> select = <span class="hljs-title function_">selectStatement</span>(
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;products&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> p.<span class="hljs-property">name</span>),
-  {},
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>),
+  { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
+<span class="hljs-comment">// select.sql: SELECT * FROM &quot;users&quot; WHERE &quot;age&quot; &gt;= $(minAge)</span>
+<span class="hljs-comment">// select.params: { minAge: 18 }</span>
+
+<span class="hljs-comment">// INSERT</span>
+<span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">insertStatement</span>(
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: params.<span class="hljs-property">name</span>, <span class="hljs-attr">age</span>: params.<span class="hljs-property">age</span> }),
+  { <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Alice&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">30</span> },
+);
+<span class="hljs-comment">// insert.sql: INSERT INTO &quot;users&quot; (&quot;name&quot;, &quot;age&quot;) VALUES ($(name), $(age))</span>
+
+<span class="hljs-comment">// UPDATE</span>
+<span class="hljs-keyword">const</span> update = <span class="hljs-title function_">updateStatement</span>(
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: params.<span class="hljs-property">newAge</span> }).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === params.<span class="hljs-property">userId</span>),
+  { <span class="hljs-attr">newAge</span>: <span class="hljs-number">31</span>, <span class="hljs-attr">userId</span>: <span class="hljs-number">1</span> },
+);
+<span class="hljs-comment">// update.sql: UPDATE &quot;users&quot; SET &quot;age&quot; = $(newAge) WHERE &quot;id&quot; = $(userId)</span>
+
+<span class="hljs-comment">// DELETE</span>
+<span class="hljs-keyword">const</span> del = <span class="hljs-title function_">deleteStatement</span>(
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt; params.<span class="hljs-property">minAge</span>),
+  { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
+);
+<span class="hljs-comment">// del.sql: DELETE FROM &quot;users&quot; WHERE &quot;age&quot; &lt; $(minAge)</span>
 </code></pre>
 <h2 id="core-features" tabindex="-1"><a class="anchor" href="#core-features" aria-hidden="true">#</a> Core Features</h2>
 <h3 id="type-safe-query-building" tabindex="-1"><a class="anchor" href="#type-safe-query-building" aria-hidden="true">#</a> Type-Safe Query Building</h3>
@@ -291,9 +344,11 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <pre class="hljs"><code><span class="hljs-comment">// External parameters via params object</span>
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-keyword">const</span> sample = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, p</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= p.<span class="hljs-property">minAge</span>), {
-  <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span>,
-});
+<span class="hljs-keyword">const</span> sample = <span class="hljs-title function_">selectStatement</span>(
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>),
+  { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
+);
 <span class="hljs-comment">// SQL (PostgreSQL): SELECT * FROM &quot;users&quot; WHERE &quot;age&quot; &gt;= $(minAge)</span>
 <span class="hljs-comment">// params: { minAge: 18 }</span>
 
@@ -307,9 +362,9 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
 <span class="hljs-keyword">const</span> <span class="hljs-title function_">query</span> = (<span class="hljs-params">q, params, helpers</span>) =&gt;
-  q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> helpers.<span class="hljs-title function_">contains</span>(u.<span class="hljs-property">name</span>, <span class="hljs-string">&quot;alice&quot;</span>)); <span class="hljs-comment">// Case-insensitive substring match</span>
+  q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> helpers.<span class="hljs-title function_">contains</span>(u.<span class="hljs-property">name</span>, params.<span class="hljs-property">searchTerm</span>)); <span class="hljs-comment">// Case-insensitive substring match</span>
 
-<span class="hljs-comment">// PostgreSQL: WHERE u.name ILIKE $1 (param: &quot;%alice%&quot;)</span>
+<span class="hljs-comment">// PostgreSQL: WHERE u.name ILIKE $(searchTerm) (param: &quot;%alice%&quot;)</span>
 <span class="hljs-comment">// SQLite: WHERE LOWER(u.name) LIKE LOWER(?) (param: &quot;%alice%&quot;)</span>
 </code></pre>
 <h2 id="key-concepts" tabindex="-1"><a class="anchor" href="#key-concepts" aria-hidden="true">#</a> Key Concepts</h2>
@@ -401,7 +456,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
   <li><a href="#installation">Installation</a></li>
   <li><a href="#quick-start">Quick Start</a></li>
   <li class="toc-sub"><a href="#postgresql-example">PostgreSQL Example</a></li>
-  <li class="toc-sub"><a href="#sqlite-example">SQLite Example</a></li>
+  <li class="toc-sub"><a href="#sql-generation-without-execution">SQL Generation Without Execution</a></li>
   <li><a href="#core-features">Core Features</a></li>
   <li class="toc-sub"><a href="#type-safe-query-building">Type-Safe Query Building</a></li>
   <li class="toc-sub"><a href="#joins">Joins</a></li>


### PR DESCRIPTION
- Updated with standardized parameter naming (params instead of p)
- Added database portability example showing identical query works with SQLite
- Added SQL generation section explaining execute* vs *Statement functions
- Removed executeSelectSimple references

🤖 Generated with [Claude Code](https://claude.com/claude-code)