### PR TITLE
docs: regenerate website with documentation fixes

### DIFF
--- a/build/api-reference.html
+++ b/build/api-reference.html
@@ -73,7 +73,7 @@
 </li>
 <li><a href="#2-type-safe-contexts">2. Type-Safe Contexts</a>
 <ul>
-<li><a href="#21-createcontext">2.1 createSchema</a></li>
+<li><a href="#21-createschema">2.1 createSchema</a></li>
 </ul>
 </li>
 <li><a href="#3-helper-utilities">3. Helper Utilities</a>

--- a/build/guide.html
+++ b/build/guide.html
@@ -156,7 +156,7 @@
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-keyword">const</span> adults = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>), {});
+<span class="hljs-keyword">const</span> adults = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>), {});
 </code></pre>
 <pre class="hljs"><code><span class="hljs-comment">-- PostgreSQL</span>
 <span class="hljs-keyword">SELECT</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">WHERE</span> &quot;age&quot; <span class="hljs-operator">&gt;=</span> $(__p1)
@@ -170,7 +170,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> activeRange = <span class="hljs-title function_">selectStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">21</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt;= <span class="hljs-number">60</span>)
@@ -192,7 +192,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> premium = <span class="hljs-title function_">selectStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> (u.<span class="hljs-property">salary</span> * <span class="hljs-number">0.9</span> &gt; <span class="hljs-number">150_000</span> &amp;&amp; u.<span class="hljs-property">age</span> &lt; <span class="hljs-number">55</span>) || u.<span class="hljs-property">active</span> === <span class="hljs-literal">false</span>),
+    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> (u.<span class="hljs-property">salary</span> * <span class="hljs-number">0.9</span> &gt; <span class="hljs-number">150_000</span> &amp;&amp; u.<span class="hljs-property">age</span> &lt; <span class="hljs-number">55</span>) || u.<span class="hljs-property">active</span> === <span class="hljs-literal">false</span>),
   {},
 );
 </code></pre>
@@ -209,7 +209,7 @@
 <h3 id="14-null-checks-and-null-coalescing" tabindex="-1"><a class="anchor" href="#14-null-checks-and-null-coalescing" aria-hidden="true">#</a> 1.4 Null Checks and Null Coalescing</h3>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> preferredName = <span class="hljs-title function_">selectStatement</span>(
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> (u.<span class="hljs-property">nickname</span> ?? u.<span class="hljs-property">name</span>) === <span class="hljs-string">&quot;anonymous&quot;</span>),
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> (u.<span class="hljs-property">nickname</span> ?? u.<span class="hljs-property">name</span>) === <span class="hljs-string">&quot;anonymous&quot;</span>),
   {},
 );
 </code></pre>
@@ -225,7 +225,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> emailFilters = <span class="hljs-title function_">selectStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">email</span>.<span class="hljs-title function_">startsWith</span>(<span class="hljs-string">&quot;admin&quot;</span>))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">email</span>.<span class="hljs-title function_">endsWith</span>(<span class="hljs-string">&quot;@example.com&quot;</span>))
@@ -265,7 +265,7 @@
 <h3 id="17-array-membership-(in)" tabindex="-1"><a class="anchor" href="#17-array-membership-(in)" aria-hidden="true">#</a> 1.7 Array Membership (IN)</h3>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> allowed = <span class="hljs-title function_">selectStatement</span>(
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> [<span class="hljs-string">&quot;admin&quot;</span>, <span class="hljs-string">&quot;support&quot;</span>, <span class="hljs-string">&quot;auditor&quot;</span>].<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">role</span>)),
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> [<span class="hljs-string">&quot;admin&quot;</span>, <span class="hljs-string">&quot;support&quot;</span>, <span class="hljs-string">&quot;auditor&quot;</span>].<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">role</span>)),
   {},
 );
 </code></pre>
@@ -326,7 +326,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> summary = <span class="hljs-title function_">selectStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({
@@ -349,12 +349,12 @@
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">ProductSchema</span> {
   <span class="hljs-attr">products</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">price</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">discount</span>: <span class="hljs-built_in">number</span> | <span class="hljs-literal">null</span> };
 }
-<span class="hljs-keyword">const</span> productContext = createSchema&lt;<span class="hljs-title class_">ProductSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">ProductSchema</span>&gt;();
 
 <span class="hljs-keyword">const</span> pricing = <span class="hljs-title function_">selectStatement</span>(
-  productContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;products&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> ({
+    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;products&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> ({
       <span class="hljs-attr">id</span>: p.<span class="hljs-property">id</span>,
       <span class="hljs-attr">name</span>: p.<span class="hljs-property">name</span>,
       <span class="hljs-attr">effectivePrice</span>: p.<span class="hljs-property">price</span> - (p.<span class="hljs-property">discount</span> ?? <span class="hljs-number">0</span>),
@@ -374,7 +374,7 @@
 <h2 id="3-ordering" tabindex="-1"><a class="anchor" href="#3-ordering" aria-hidden="true">#</a> 3. Ordering</h2>
 <p>Methods <code>orderBy</code>, <code>orderByDescending</code>, <code>thenBy</code>, and <code>thenByDescending</code> control result ordering.</p>
 <h3 id="31-single-key-ascending" tabindex="-1"><a class="anchor" href="#31-single-key-ascending" aria-hidden="true">#</a> 3.1 Single Key Ascending</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> alphabetical = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>), {});
+<pre class="hljs"><code><span class="hljs-keyword">const</span> alphabetical = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>), {});
 </code></pre>
 <pre class="hljs"><code><span class="hljs-comment">-- PostgreSQL</span>
 <span class="hljs-keyword">SELECT</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">ORDER</span> <span class="hljs-keyword">BY</span> &quot;name&quot; <span class="hljs-keyword">ASC</span>
@@ -386,7 +386,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> ordered = <span class="hljs-title function_">selectStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>)
       .<span class="hljs-title function_">thenByDescending</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">salary</span>)
@@ -405,7 +405,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> departments = <span class="hljs-title function_">selectStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>)
       .<span class="hljs-title function_">distinct</span>(),
@@ -425,7 +425,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> page = <span class="hljs-title function_">selectStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span>)
       .<span class="hljs-title function_">skip</span>(<span class="hljs-number">30</span>)
@@ -445,7 +445,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> filteredPage = <span class="hljs-title function_">selectStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>)
@@ -470,13 +470,13 @@
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">departmentId</span>: <span class="hljs-built_in">number</span> };
   <span class="hljs-attr">departments</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span> };
 }
-<span class="hljs-keyword">const</span> joinContext = createSchema&lt;<span class="hljs-title class_">JoinSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">JoinSchema</span>&gt;();
 
 <span class="hljs-keyword">const</span> userDepartments = <span class="hljs-title function_">selectStatement</span>(
-  joinContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">join</span>(
-      ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;departments&quot;</span>),
+    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">join</span>(
+      q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;departments&quot;</span>),
       <span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>,
       <span class="hljs-function">(<span class="hljs-params">d</span>) =&gt;</span> d.<span class="hljs-property">id</span>,
       <span class="hljs-function">(<span class="hljs-params">u, d</span>) =&gt;</span> ({ <span class="hljs-attr">userName</span>: u.<span class="hljs-property">name</span>, <span class="hljs-attr">departmentName</span>: d.<span class="hljs-property">name</span> }),
@@ -499,16 +499,16 @@
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span> };
   <span class="hljs-attr">orders</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">userId</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">total</span>: <span class="hljs-built_in">number</span> };
 }
-<span class="hljs-keyword">const</span> orderContext = createSchema&lt;<span class="hljs-title class_">OrderSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">OrderSchema</span>&gt;();
 
 <span class="hljs-keyword">const</span> regionOrders = <span class="hljs-title function_">selectStatement</span>(
-  orderContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> &gt; <span class="hljs-number">100</span>)
       .<span class="hljs-title function_">join</span>(
-        ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;orders&quot;</span>),
+        q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;orders&quot;</span>),
         <span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span>,
         <span class="hljs-function">(<span class="hljs-params">o</span>) =&gt;</span> o.<span class="hljs-property">userId</span>,
         <span class="hljs-function">(<span class="hljs-params">u, o</span>) =&gt;</span> ({ <span class="hljs-attr">userName</span>: u.<span class="hljs-property">name</span>, <span class="hljs-attr">total</span>: o.<span class="hljs-property">total</span> }),
@@ -533,12 +533,12 @@
 </code></pre>
 <h3 id="63-join-with-grouped-results" tabindex="-1"><a class="anchor" href="#63-join-with-grouped-results" aria-hidden="true">#</a> 6.3 Join with Grouped Results</h3>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> totalsByDepartment = <span class="hljs-title function_">selectStatement</span>(
-  orderContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">join</span>(
-        ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;orders&quot;</span>),
+        q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;orders&quot;</span>),
         <span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span>,
         <span class="hljs-function">(<span class="hljs-params">o</span>) =&gt;</span> o.<span class="hljs-property">userId</span>,
         <span class="hljs-function">(<span class="hljs-params">u, o</span>) =&gt;</span> ({ u, o }),
@@ -567,12 +567,12 @@
 <h3 id="64-left-outer-join" tabindex="-1"><a class="anchor" href="#64-left-outer-join" aria-hidden="true">#</a> 6.4 Left Outer Join</h3>
 <p>Model the classic LINQ pattern: start with <code>groupJoin</code>, then expand the grouped results with <code>selectMany(...defaultIfEmpty())</code>. Any missing matches appear as <code>null</code> in the projection.</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> usersWithDepartments = <span class="hljs-title function_">selectStatement</span>(
-  joinContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">groupJoin</span>(
-        ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;departments&quot;</span>),
+        q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;departments&quot;</span>),
         <span class="hljs-function">(<span class="hljs-params">user</span>) =&gt;</span> user.<span class="hljs-property">departmentId</span>,
         <span class="hljs-function">(<span class="hljs-params">department</span>) =&gt;</span> department.<span class="hljs-property">id</span>,
         <span class="hljs-function">(<span class="hljs-params">user, deptGroup</span>) =&gt;</span> ({ user, deptGroup }),
@@ -601,12 +601,12 @@
 <h3 id="65-cross-join" tabindex="-1"><a class="anchor" href="#65-cross-join" aria-hidden="true">#</a> 6.5 Cross Join</h3>
 <p>Return a <code>Queryable</code> from the collection selector passed to <code>selectMany</code>. Because we skip <code>defaultIfEmpty</code>, the parser normalizes the operation into a <code>CROSS JOIN</code>.</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> departmentUsers = <span class="hljs-title function_">selectStatement</span>(
-  joinContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;departments&quot;</span>)
       .<span class="hljs-title function_">selectMany</span>(
-        <span class="hljs-function">() =&gt;</span> ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>),
+        <span class="hljs-function">() =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>),
         <span class="hljs-function">(<span class="hljs-params">department, user</span>) =&gt;</span> ({ department, user }),
       )
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">row</span>) =&gt;</span> ({
@@ -633,7 +633,7 @@
 <h3 id="71-basic-grouping" tabindex="-1"><a class="anchor" href="#71-basic-grouping" aria-hidden="true">#</a> 7.1 Basic Grouping</h3>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> byDepartment = <span class="hljs-title function_">selectStatement</span>(
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">groupBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>),
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">groupBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>),
   {},
 );
 </code></pre>
@@ -647,7 +647,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> departmentStats = <span class="hljs-title function_">selectStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">groupBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">g</span>) =&gt;</span> ({
@@ -678,7 +678,7 @@
   db,
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">groupBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">g</span>) =&gt;</span> ({ <span class="hljs-attr">departmentId</span>: g.<span class="hljs-property">key</span>, <span class="hljs-attr">headcount</span>: g.<span class="hljs-title function_">count</span>() }))
@@ -701,10 +701,10 @@
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">EmployeeSchema</span> {
   <span class="hljs-attr">employees</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">department</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">salary</span>: <span class="hljs-built_in">number</span> };
 }
-<span class="hljs-keyword">const</span> empContext = createSchema&lt;<span class="hljs-title class_">EmployeeSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">EmployeeSchema</span>&gt;();
 
 <span class="hljs-keyword">const</span> rankedEmployees = <span class="hljs-title function_">selectStatement</span>(
-  empContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
@@ -733,10 +733,10 @@
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">OrderTimeSchema</span> {
   <span class="hljs-attr">orders</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">createdAt</span>: <span class="hljs-title class_">Date</span> };
 }
-<span class="hljs-keyword">const</span> orderTimeContext = createSchema&lt;<span class="hljs-title class_">OrderTimeSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">OrderTimeSchema</span>&gt;();
 
 <span class="hljs-keyword">const</span> chronological = <span class="hljs-title function_">selectStatement</span>(
-  orderTimeContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;orders&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">o</span>) =&gt;</span> ({
       <span class="hljs-attr">orderId</span>: o.<span class="hljs-property">id</span>,
@@ -756,10 +756,10 @@
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">RegionEmployeeSchema</span> {
   <span class="hljs-attr">employees</span>: { <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">region</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">department</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">salary</span>: <span class="hljs-built_in">number</span> };
 }
-<span class="hljs-keyword">const</span> regionEmpContext = createSchema&lt;<span class="hljs-title class_">RegionEmployeeSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">RegionEmployeeSchema</span>&gt;();
 
 <span class="hljs-keyword">const</span> multiPartition = <span class="hljs-title function_">selectStatement</span>(
-  regionEmpContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
@@ -782,7 +782,7 @@
 </code></pre>
 <h4 id="secondary-ordering-with-thenby" tabindex="-1"><a class="anchor" href="#secondary-ordering-with-thenby" aria-hidden="true">#</a> Secondary Ordering with thenBy</h4>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> ranked = <span class="hljs-title function_">selectStatement</span>(
-  empContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
@@ -804,7 +804,7 @@
 <h3 id="82-rank" tabindex="-1"><a class="anchor" href="#82-rank" aria-hidden="true">#</a> 8.2 RANK</h3>
 <p><code>RANK()</code> assigns ranks with gaps for tied values. If two rows have the same rank, the next rank skips numbers.</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> rankedSalaries = <span class="hljs-title function_">selectStatement</span>(
-  empContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
@@ -860,10 +860,10 @@
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">PlayerSchema</span> {
   <span class="hljs-attr">players</span>: { <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">score</span>: <span class="hljs-built_in">number</span> };
 }
-<span class="hljs-keyword">const</span> playerContext = createSchema&lt;<span class="hljs-title class_">PlayerSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">PlayerSchema</span>&gt;();
 
 <span class="hljs-keyword">const</span> globalRank = <span class="hljs-title function_">selectStatement</span>(
-  playerContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;players&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> ({
       <span class="hljs-attr">player</span>: p.<span class="hljs-property">name</span>,
@@ -883,7 +883,7 @@
 <h3 id="83-dense_rank" tabindex="-1"><a class="anchor" href="#83-dense_rank" aria-hidden="true">#</a> 8.3 DENSE_RANK</h3>
 <p><code>DENSE_RANK()</code> assigns ranks without gaps. Tied values receive the same rank, and the next rank is consecutive.</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> denseRanked = <span class="hljs-title function_">selectStatement</span>(
-  empContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
@@ -938,10 +938,10 @@
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">EmployeeAgeSchema</span> {
   <span class="hljs-attr">employees</span>: { <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">department</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">salary</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span> };
 }
-<span class="hljs-keyword">const</span> empAgeContext = createSchema&lt;<span class="hljs-title class_">EmployeeAgeSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">EmployeeAgeSchema</span>&gt;();
 
 <span class="hljs-keyword">const</span> complexRanking = <span class="hljs-title function_">selectStatement</span>(
-  empAgeContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
@@ -967,7 +967,7 @@
 <h3 id="84-multiple-window-functions" tabindex="-1"><a class="anchor" href="#84-multiple-window-functions" aria-hidden="true">#</a> 8.4 Multiple Window Functions</h3>
 <p>Combine multiple window functions in a single SELECT:</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> allRankings = <span class="hljs-title function_">selectStatement</span>(
-  empContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
@@ -1012,7 +1012,7 @@
 <p>Get the top earner from each department:</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> topEarners = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  empContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
@@ -1050,11 +1050,11 @@
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">EmployeeDeptSchema</span> {
   <span class="hljs-attr">employees</span>: { <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">salary</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">department_id</span>: <span class="hljs-built_in">number</span> };
 }
-<span class="hljs-keyword">const</span> empDeptContext = createSchema&lt;<span class="hljs-title class_">EmployeeDeptSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">EmployeeDeptSchema</span>&gt;();
 
 <span class="hljs-keyword">const</span> top3Engineering = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  empDeptContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
@@ -1086,11 +1086,11 @@
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">PerformanceSchema</span> {
   <span class="hljs-attr">employees</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">performance_score</span>: <span class="hljs-built_in">number</span> };
 }
-<span class="hljs-keyword">const</span> perfContext = createSchema&lt;<span class="hljs-title class_">PerformanceSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">PerformanceSchema</span>&gt;();
 
 <span class="hljs-keyword">const</span> topPerformers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  perfContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
@@ -1117,11 +1117,11 @@
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">ActiveEmployeeSchema</span> {
   <span class="hljs-attr">employees</span>: { <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">department</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">salary</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">is_active</span>: <span class="hljs-built_in">boolean</span> };
 }
-<span class="hljs-keyword">const</span> activeEmpContext = createSchema&lt;<span class="hljs-title class_">ActiveEmployeeSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">ActiveEmployeeSchema</span>&gt;();
 
 <span class="hljs-keyword">const</span> activeTopEarners = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  activeEmpContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
@@ -1159,7 +1159,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> totals = <span class="hljs-title function_">selectStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span> === <span class="hljs-literal">true</span>)
       .<span class="hljs-title function_">sum</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">salary</span>),
@@ -1175,7 +1175,7 @@
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;__p1&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <p>Methods <code>count</code>, <code>average</code>, <code>min</code>, and <code>max</code> follow the same structure. The <code>count</code> method also accepts a predicate:</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> activeCount = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">count</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span>), {});
+<pre class="hljs"><code><span class="hljs-keyword">const</span> activeCount = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">count</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span>), {});
 </code></pre>
 <pre class="hljs"><code><span class="hljs-comment">-- PostgreSQL</span>
 <span class="hljs-keyword">SELECT</span> <span class="hljs-built_in">COUNT</span>(<span class="hljs-operator">*</span>) <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">WHERE</span> &quot;active&quot;
@@ -1187,7 +1187,7 @@
 <h2 id="10-quantifiers" tabindex="-1"><a class="anchor" href="#10-quantifiers" aria-hidden="true">#</a> 10. Quantifiers</h2>
 <p>Methods <code>any</code> and <code>all</code> test whether elements satisfy conditions.</p>
 <h3 id="101-any-operation" tabindex="-1"><a class="anchor" href="#101-any-operation" aria-hidden="true">#</a> 10.1 Any Operation</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> hasAdults = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">any</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>), {});
+<pre class="hljs"><code><span class="hljs-keyword">const</span> hasAdults = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">any</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>), {});
 </code></pre>
 <pre class="hljs"><code><span class="hljs-comment">-- PostgreSQL</span>
 <span class="hljs-keyword">SELECT</span> <span class="hljs-keyword">CASE</span> <span class="hljs-keyword">WHEN</span> <span class="hljs-keyword">EXISTS</span>(<span class="hljs-keyword">SELECT</span> <span class="hljs-number">1</span> <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">WHERE</span> &quot;age&quot; <span class="hljs-operator">&gt;=</span> $(__p1)) <span class="hljs-keyword">THEN</span> <span class="hljs-number">1</span> <span class="hljs-keyword">ELSE</span> <span class="hljs-number">0</span> <span class="hljs-keyword">END</span>
@@ -1201,7 +1201,7 @@
 <p>The <code>all</code> method emits a <code>NOT EXISTS</code> check:</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> allActive = <span class="hljs-title function_">selectStatement</span>(
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">all</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span> === <span class="hljs-literal">true</span>),
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">all</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span> === <span class="hljs-literal">true</span>),
   {},
 );
 </code></pre>
@@ -1217,7 +1217,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> newestUser = <span class="hljs-title function_">selectStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">createdAt</span>)
       .<span class="hljs-title function_">last</span>(),
@@ -1242,7 +1242,7 @@
   db,
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
@@ -1346,7 +1346,7 @@
 <span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">insertStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
+    q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
       <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Alice&quot;</span>,
       <span class="hljs-attr">age</span>: <span class="hljs-number">30</span>,
       <span class="hljs-attr">email</span>: <span class="hljs-string">&quot;alice@example.com&quot;</span>,
@@ -1390,7 +1390,7 @@
 <span class="hljs-keyword">const</span> insertWithReturn = <span class="hljs-title function_">insertStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Charlie&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">35</span> })
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">createdAt</span>: u.<span class="hljs-property">createdAt</span> })),
@@ -1401,7 +1401,7 @@
 <span class="hljs-keyword">const</span> insertReturnAll = <span class="hljs-title function_">insertStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;David&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">40</span> })
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u), <span class="hljs-comment">// Returns *</span>
@@ -1412,7 +1412,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">insertStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
+    q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
       <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Eve&quot;</span>,
       <span class="hljs-attr">email</span>: <span class="hljs-literal">null</span>, <span class="hljs-comment">// Generates NULL, not parameterized</span>
       <span class="hljs-attr">phone</span>: <span class="hljs-literal">undefined</span>, <span class="hljs-comment">// Column omitted from INSERT</span>
@@ -1431,7 +1431,7 @@
 <span class="hljs-keyword">const</span> updateStmt = <span class="hljs-title function_">updateStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: <span class="hljs-number">31</span>, <span class="hljs-attr">lastModified</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>() })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">1</span>),
@@ -1468,7 +1468,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> updateStmt = <span class="hljs-title function_">updateStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">lastLogin</span> &lt; <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>(<span class="hljs-string">&quot;2023-01-01&quot;</span>) &amp;&amp; u.<span class="hljs-property">role</span> !== <span class="hljs-string">&quot;admin&quot;</span>),
@@ -1479,7 +1479,7 @@
 <pre class="hljs"><code><span class="hljs-keyword">const</span> updateWithReturn = <span class="hljs-title function_">updateStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: <span class="hljs-number">32</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">2</span>)
@@ -1491,7 +1491,7 @@
 <pre class="hljs"><code><span class="hljs-comment">// UPDATE without WHERE requires explicit permission</span>
 <span class="hljs-keyword">const</span> updateAll = <span class="hljs-title function_">updateStatement</span>(
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">set</span>({ <span class="hljs-attr">isActive</span>: <span class="hljs-literal">true</span> }).<span class="hljs-title function_">allowFullTableUpdate</span>(), <span class="hljs-comment">// Required flag</span>
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">set</span>({ <span class="hljs-attr">isActive</span>: <span class="hljs-literal">true</span> }).<span class="hljs-title function_">allowFullTableUpdate</span>(), <span class="hljs-comment">// Required flag</span>
   {},
 );
 </code></pre>
@@ -1507,7 +1507,7 @@ Full table updates are dangerous and must be explicitly allowed.
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-keyword">const</span> del = <span class="hljs-title function_">deleteStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">100</span>), {});
+<span class="hljs-keyword">const</span> del = <span class="hljs-title function_">deleteStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">100</span>), {});
 </code></pre>
 <p>Generated SQL:</p>
 <pre class="hljs"><code><span class="hljs-keyword">DELETE</span> <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">WHERE</span> &quot;age&quot; <span class="hljs-operator">&gt;</span> $(__p1)  <span class="hljs-comment">-- PostgreSQL</span>
@@ -1517,7 +1517,7 @@ Full table updates are dangerous and must be explicitly allowed.
 <pre class="hljs"><code><span class="hljs-keyword">const</span> del = <span class="hljs-title function_">deleteStatement</span>(
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">isDeleted</span> === <span class="hljs-literal">true</span> || (u.<span class="hljs-property">age</span> &lt; <span class="hljs-number">18</span> &amp;&amp; u.<span class="hljs-property">role</span> !== <span class="hljs-string">&quot;admin&quot;</span>) || u.<span class="hljs-property">email</span> === <span class="hljs-literal">null</span>),
   {},
@@ -1552,7 +1552,7 @@ Full table updates are dangerous and must be explicitly allowed.
 <pre class="hljs"><code><span class="hljs-comment">// DELETE without WHERE requires explicit permission</span>
 <span class="hljs-keyword">const</span> deleteAll = <span class="hljs-title function_">deleteStatement</span>(
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">allowFullTableDelete</span>(), <span class="hljs-comment">// Required flag</span>
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">allowFullTableDelete</span>(), <span class="hljs-comment">// Required flag</span>
   {},
 );
 </code></pre>
@@ -1561,24 +1561,24 @@ Full table updates are dangerous and must be explicitly allowed.
 <h4 id="mandatory-where-clauses" tabindex="-1"><a class="anchor" href="#mandatory-where-clauses" aria-hidden="true">#</a> Mandatory WHERE Clauses</h4>
 <p>UPDATE and DELETE operations require WHERE clauses by default to prevent accidental full-table operations:</p>
 <pre class="hljs"><code><span class="hljs-comment">// This throws an error</span>
-<span class="hljs-title function_">deleteStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>), {});
+<span class="hljs-title function_">deleteStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>), {});
 <span class="hljs-comment">// Error: DELETE requires a WHERE clause or explicit allowFullTableDelete()</span>
 
 <span class="hljs-comment">// This works</span>
-<span class="hljs-title function_">deleteStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">allowFullTableDelete</span>(), {});
+<span class="hljs-title function_">deleteStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">allowFullTableDelete</span>(), {});
 </code></pre>
 <h4 id="type-safety" tabindex="-1"><a class="anchor" href="#type-safety" aria-hidden="true">#</a> Type Safety</h4>
 <p>All CRUD operations maintain full TypeScript type safety:</p>
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">UserSchema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">email</span>: <span class="hljs-built_in">string</span> | <span class="hljs-literal">null</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span> };
 }
-<span class="hljs-keyword">const</span> userContext = createSchema&lt;<span class="hljs-title class_">UserSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">UserSchema</span>&gt;();
 
 <span class="hljs-comment">// Type error: &#x27;username&#x27; doesn&#x27;t exist on users table</span>
 <span class="hljs-title function_">insertStatement</span>(
-  userContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
+    q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
       <span class="hljs-attr">username</span>: <span class="hljs-string">&quot;Alice&quot;</span>, <span class="hljs-comment">// ❌ Type error</span>
     }),
   {},
@@ -1586,9 +1586,9 @@ Full table updates are dangerous and must be explicitly allowed.
 
 <span class="hljs-comment">// Type error: age must be number</span>
 <span class="hljs-title function_">updateStatement</span>(
-  userContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx.<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">set</span>({
+    q.<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">set</span>({
       <span class="hljs-attr">age</span>: <span class="hljs-string">&quot;30&quot;</span>, <span class="hljs-comment">// ❌ Type error - must be number</span>
     }),
   {},
@@ -1598,9 +1598,9 @@ Full table updates are dangerous and must be explicitly allowed.
 <p>All values are automatically parameterized to prevent SQL injection:</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> maliciousName = <span class="hljs-string">&quot;&#x27;; DROP TABLE users; --&quot;</span>;
 <span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">insertStatement</span>(
-  userContext,
+  schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
+    q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
       <span class="hljs-attr">name</span>: maliciousName, <span class="hljs-comment">// Safely parameterized</span>
     }),
   {},
@@ -1618,7 +1618,7 @@ Full table updates are dangerous and must be explicitly allowed.
   db,
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Frank&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">28</span> })
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
@@ -1631,7 +1631,7 @@ Full table updates are dangerous and must be explicitly allowed.
   db,
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: <span class="hljs-number">29</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">123</span>),
@@ -1643,7 +1643,7 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-keyword">const</span> deleteCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeDelete</span>(
   db,
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">123</span>),
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">123</span>),
   {},
 );
 </code></pre>
@@ -1654,7 +1654,7 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-keyword">const</span> insertCount = <span class="hljs-title function_">executeInsert</span>(
   db,
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Grace&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">30</span> }),
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Grace&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">30</span> }),
   {},
 );
 <span class="hljs-comment">// Returns number of inserted rows</span>
@@ -1664,7 +1664,7 @@ Full table updates are dangerous and must be explicitly allowed.
   db,
   schema,
   <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    ctx
+    q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: <span class="hljs-number">33</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span> === <span class="hljs-string">&quot;Henry&quot;</span>),
@@ -1675,7 +1675,7 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-keyword">const</span> deleteCount = <span class="hljs-title function_">executeDelete</span>(
   db,
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">100</span>),
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">100</span>),
   {},
 );
 </code></pre>
@@ -1686,15 +1686,15 @@ Full table updates are dangerous and must be explicitly allowed.
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">lastLogin</span>: <span class="hljs-title class_">Date</span> };
   <span class="hljs-attr">user_logs</span>: { <span class="hljs-attr">userId</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">action</span>: <span class="hljs-built_in">string</span> };
 }
-<span class="hljs-keyword">const</span> txContext = createSchema&lt;<span class="hljs-title class_">TxSchema</span>&gt;();
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">TxSchema</span>&gt;();
 
 <span class="hljs-comment">// PostgreSQL transactions</span>
 <span class="hljs-keyword">await</span> db.<span class="hljs-title function_">tx</span>(<span class="hljs-title function_">async</span> (t) =&gt; {
   <span class="hljs-keyword">const</span> users = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
     t,
-    txContext,
+    schema,
     <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-      ctx
+      q
         .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
         .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Ivy&quot;</span> })
         .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span>),
@@ -1703,9 +1703,9 @@ Full table updates are dangerous and must be explicitly allowed.
 
   <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
     t,
-    txContext,
+    schema,
     <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-      ctx.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;user_logs&quot;</span>).<span class="hljs-title function_">values</span>({
+      q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;user_logs&quot;</span>).<span class="hljs-title function_">values</span>({
         <span class="hljs-attr">userId</span>: users[<span class="hljs-number">0</span>]!.<span class="hljs-property">id</span>,
         <span class="hljs-attr">action</span>: <span class="hljs-string">&quot;created&quot;</span>,
       }),
@@ -1715,12 +1715,12 @@ Full table updates are dangerous and must be explicitly allowed.
 
 <span class="hljs-comment">// SQLite transactions</span>
 <span class="hljs-keyword">const</span> transaction = sqliteDb.<span class="hljs-title function_">transaction</span>(<span class="hljs-function">() =&gt;</span> {
-  <span class="hljs-title function_">executeInsert</span>(db, txContext, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> ctx.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Jack&quot;</span> }), {});
+  <span class="hljs-title function_">executeInsert</span>(db, schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Jack&quot;</span> }), {});
   <span class="hljs-title function_">executeUpdate</span>(
     db,
-    txContext,
+    schema,
     <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-      ctx
+      q
         .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
         .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">lastLogin</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>() })
         .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span> === <span class="hljs-string">&quot;Jack&quot;</span>),

--- a/build/index.html
+++ b/build/index.html
@@ -279,7 +279,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <span class="hljs-keyword">const</span> topEarners = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
   schema,
-  <span class="hljs-function">(<span class="hljs-params">q, h</span>) =&gt;</span>
+  <span class="hljs-function">(<span class="hljs-params">q, params, h</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
@@ -291,6 +291,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
           .<span class="hljs-title function_">rowNumber</span>(),
       }))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> e.<span class="hljs-property">rank</span> === <span class="hljs-number">1</span>), <span class="hljs-comment">// Filtering on window function result</span>
+  {},
 );
 
 <span class="hljs-comment">// Generated SQL (automatically wrapped):</span>

--- a/build/llms.txt
+++ b/build/llms.txt
@@ -269,7 +269,7 @@ Window functions enable calculations across rows related to the current row. Tin
 const topEarners = await executeSelect(
   db,
   schema,
-  (q, h) =>
+  (q, params, h) =>
     q
       .from("employees")
       .select((e) => ({
@@ -281,6 +281,7 @@ const topEarners = await executeSelect(
           .rowNumber(),
       }))
       .where((e) => e.rank === 1), // Filtering on window function result
+  {},
 );
 
 // Generated SQL (automatically wrapped):
@@ -745,7 +746,7 @@ Reference for adapter execution helpers, typed contexts, and query utilities.
   - [1.6 toSql](#16-tosql)
   - [1.7 ExecuteOptions & SqlResult](#17-executeoptions--sqlresult)
 - [2. Type-Safe Contexts](#2-type-safe-contexts)
-  - [2.1 createSchema](#21-createcontext)
+  - [2.1 createSchema](#21-createschema)
 - [3. Helper Utilities](#3-helper-utilities)
   - [3.1 createQueryHelpers](#31-createqueryhelpers)
 
@@ -1823,7 +1824,7 @@ interface Schema {
 
 const schema = createSchema<Schema>();
 
-const adults = selectStatement(schema, (q) => ctx.from("users").where((u) => u.age >= 18), {});
+const adults = selectStatement(schema, (q) => q.from("users").where((u) => u.age >= 18), {});
 ```
 
 ```sql
@@ -1846,7 +1847,7 @@ SELECT * FROM "users" WHERE "age" >= @__p1
 const activeRange = selectStatement(
   schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .where((u) => u.age >= 21)
       .where((u) => u.age <= 60)
@@ -1877,7 +1878,7 @@ WHERE "age" >= @__p1 AND "age" <= @__p2 AND "active" = @__p3
 const premium = selectStatement(
   schema,
   (q) =>
-    ctx.from("users").where((u) => (u.salary * 0.9 > 150_000 && u.age < 55) || u.active === false),
+    q.from("users").where((u) => (u.salary * 0.9 > 150_000 && u.age < 55) || u.active === false),
   {},
 );
 ```
@@ -1903,7 +1904,7 @@ WHERE ((("salary" * @__p1) > @__p2 AND "age" < @__p3) OR "active" = @__p4)
 ```typescript
 const preferredName = selectStatement(
   schema,
-  (q) => ctx.from("users").where((u) => (u.nickname ?? u.name) === "anonymous"),
+  (q) => q.from("users").where((u) => (u.nickname ?? u.name) === "anonymous"),
   {},
 );
 ```
@@ -1928,7 +1929,7 @@ SELECT * FROM "users" WHERE COALESCE("nickname", "name") = @__p1
 const emailFilters = selectStatement(
   schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .where((u) => u.email.startsWith("admin"))
       .where((u) => u.email.endsWith("@example.com"))
@@ -1986,7 +1987,7 @@ SELECT * FROM "users" WHERE LOWER("name") = LOWER(@__p1)
 ```typescript
 const allowed = selectStatement(
   schema,
-  (q) => ctx.from("users").where((u) => ["admin", "support", "auditor"].includes(u.role)),
+  (q) => q.from("users").where((u) => ["admin", "support", "auditor"].includes(u.role)),
   {},
 );
 ```
@@ -2076,7 +2077,7 @@ SELECT * FROM "users"
 const summary = selectStatement(
   schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .where((u) => u.active)
       .select((u) => ({
@@ -2106,12 +2107,12 @@ SELECT "id" AS "id", "name" AS "name", "email" AS "contact.email" FROM "users" W
 interface ProductSchema {
   products: { id: number; name: string; price: number; discount: number | null };
 }
-const productContext = createSchema<ProductSchema>();
+const schema = createSchema<ProductSchema>();
 
 const pricing = selectStatement(
-  productContext,
+  schema,
   (q) =>
-    ctx.from("products").select((p) => ({
+    q.from("products").select((p) => ({
       id: p.id,
       name: p.name,
       effectivePrice: p.price - (p.discount ?? 0),
@@ -2143,7 +2144,7 @@ Methods `orderBy`, `orderByDescending`, `thenBy`, and `thenByDescending` control
 ### 3.1 Single Key Ascending
 
 ```typescript
-const alphabetical = selectStatement(schema, (q) => ctx.from("users").orderBy((u) => u.name), {});
+const alphabetical = selectStatement(schema, (q) => q.from("users").orderBy((u) => u.name), {});
 ```
 
 ```sql
@@ -2162,7 +2163,7 @@ SELECT * FROM "users" ORDER BY "name" ASC
 const ordered = selectStatement(
   schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .orderBy((u) => u.departmentId)
       .thenByDescending((u) => u.salary)
@@ -2189,7 +2190,7 @@ SELECT * FROM "users" ORDER BY "departmentId" ASC, "salary" DESC, "name" ASC
 const departments = selectStatement(
   schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .select((u) => u.departmentId)
       .distinct(),
@@ -2219,7 +2220,7 @@ Methods `skip` and `take` implement OFFSET and LIMIT clauses.
 const page = selectStatement(
   schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .orderBy((u) => u.id)
       .skip(30)
@@ -2248,7 +2249,7 @@ SELECT * FROM "users" ORDER BY "id" ASC LIMIT @__p2 OFFSET @__p1
 const filteredPage = selectStatement(
   schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .where((u) => u.active)
       .orderBy((u) => u.name)
@@ -2285,13 +2286,13 @@ interface JoinSchema {
   users: { id: number; name: string; departmentId: number };
   departments: { id: number; name: string };
 }
-const joinContext = createSchema<JoinSchema>();
+const schema = createSchema<JoinSchema>();
 
 const userDepartments = selectStatement(
-  joinContext,
+  schema,
   (q) =>
-    ctx.from("users").join(
-      ctx.from("departments"),
+    q.from("users").join(
+      q.from("departments"),
       (u) => u.departmentId,
       (d) => d.id,
       (u, d) => ({ userName: u.name, departmentName: d.name }),
@@ -2321,16 +2322,16 @@ interface OrderSchema {
   users: { id: number; name: string };
   orders: { id: number; userId: number; total: number };
 }
-const orderContext = createSchema<OrderSchema>();
+const schema = createSchema<OrderSchema>();
 
 const regionOrders = selectStatement(
-  orderContext,
+  schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .where((u) => u.id > 100)
       .join(
-        ctx.from("orders"),
+        q.from("orders"),
         (u) => u.id,
         (o) => o.userId,
         (u, o) => ({ userName: u.name, total: o.total }),
@@ -2364,12 +2365,12 @@ WHERE "t0"."id" > @__p1 AND "t1"."total" > @__p2
 
 ```typescript
 const totalsByDepartment = selectStatement(
-  orderContext,
+  schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .join(
-        ctx.from("orders"),
+        q.from("orders"),
         (u) => u.id,
         (o) => o.userId,
         (u, o) => ({ u, o }),
@@ -2406,12 +2407,12 @@ Model the classic LINQ pattern: start with `groupJoin`, then expand the grouped 
 
 ```typescript
 const usersWithDepartments = selectStatement(
-  joinContext,
+  schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .groupJoin(
-        ctx.from("departments"),
+        q.from("departments"),
         (user) => user.departmentId,
         (department) => department.id,
         (user, deptGroup) => ({ user, deptGroup }),
@@ -2448,12 +2449,12 @@ Return a `Queryable` from the collection selector passed to `selectMany`. Becaus
 
 ```typescript
 const departmentUsers = selectStatement(
-  joinContext,
+  schema,
   (q) =>
-    ctx
+    q
       .from("departments")
       .selectMany(
-        () => ctx.from("users"),
+        () => q.from("users"),
         (department, user) => ({ department, user }),
       )
       .select((row) => ({
@@ -2491,7 +2492,7 @@ The `groupBy` method groups results and enables aggregate functions: `count`, `s
 ```typescript
 const byDepartment = selectStatement(
   schema,
-  (q) => ctx.from("users").groupBy((u) => u.departmentId),
+  (q) => q.from("users").groupBy((u) => u.departmentId),
   {},
 );
 ```
@@ -2512,7 +2513,7 @@ SELECT "departmentId" FROM "users" GROUP BY "departmentId"
 const departmentStats = selectStatement(
   schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .groupBy((u) => u.departmentId)
       .select((g) => ({
@@ -2550,7 +2551,7 @@ const largeDepartments = await executeSelect(
   db,
   schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .groupBy((u) => u.departmentId)
       .select((g) => ({ departmentId: g.key, headcount: g.count() }))
@@ -2581,10 +2582,10 @@ All window functions are accessed via the helpers parameter (second parameter in
 interface EmployeeSchema {
   employees: { id: number; name: string; department: string; salary: number };
 }
-const empContext = createSchema<EmployeeSchema>();
+const schema = createSchema<EmployeeSchema>();
 
 const rankedEmployees = selectStatement(
-  empContext,
+  schema,
   (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
@@ -2620,10 +2621,10 @@ FROM "employees"
 interface OrderTimeSchema {
   orders: { id: number; createdAt: Date };
 }
-const orderTimeContext = createSchema<OrderTimeSchema>();
+const schema = createSchema<OrderTimeSchema>();
 
 const chronological = selectStatement(
-  orderTimeContext,
+  schema,
   (q, params, helpers) =>
     q.from("orders").select((o) => ({
       orderId: o.id,
@@ -2648,10 +2649,10 @@ FROM "orders"
 interface RegionEmployeeSchema {
   employees: { name: string; region: string; department: string; salary: number };
 }
-const regionEmpContext = createSchema<RegionEmployeeSchema>();
+const schema = createSchema<RegionEmployeeSchema>();
 
 const multiPartition = selectStatement(
-  regionEmpContext,
+  schema,
   (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
@@ -2679,7 +2680,7 @@ FROM "employees"
 
 ```typescript
 const ranked = selectStatement(
-  empContext,
+  schema,
   (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
@@ -2707,7 +2708,7 @@ FROM "employees"
 
 ```typescript
 const rankedSalaries = selectStatement(
-  empContext,
+  schema,
   (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
@@ -2752,10 +2753,10 @@ Notice rank 2 is skipped because two employees share rank 1.
 interface PlayerSchema {
   players: { name: string; score: number };
 }
-const playerContext = createSchema<PlayerSchema>();
+const schema = createSchema<PlayerSchema>();
 
 const globalRank = selectStatement(
-  playerContext,
+  schema,
   (q, params, helpers) =>
     q.from("players").select((p) => ({
       player: p.name,
@@ -2781,7 +2782,7 @@ FROM "players"
 
 ```typescript
 const denseRanked = selectStatement(
-  empContext,
+  schema,
   (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
@@ -2824,10 +2825,10 @@ Example result without gaps:
 interface EmployeeAgeSchema {
   employees: { name: string; department: string; salary: number; age: number };
 }
-const empAgeContext = createSchema<EmployeeAgeSchema>();
+const schema = createSchema<EmployeeAgeSchema>();
 
 const complexRanking = selectStatement(
-  empAgeContext,
+  schema,
   (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
@@ -2859,7 +2860,7 @@ Combine multiple window functions in a single SELECT:
 
 ```typescript
 const allRankings = selectStatement(
-  empContext,
+  schema,
   (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
@@ -2914,7 +2915,7 @@ Get the top earner from each department:
 ```typescript
 const topEarners = await executeSelect(
   db,
-  empContext,
+  schema,
   (q, params, helpers) =>
     q
       .from("employees")
@@ -2960,11 +2961,11 @@ Get the top 3 highest-paid employees from a specific department:
 interface EmployeeDeptSchema {
   employees: { name: string; salary: number; department_id: number };
 }
-const empDeptContext = createSchema<EmployeeDeptSchema>();
+const schema = createSchema<EmployeeDeptSchema>();
 
 const top3Engineering = await executeSelect(
   db,
-  empDeptContext,
+  schema,
   (q, params, helpers) =>
     q
       .from("employees")
@@ -3002,11 +3003,11 @@ The spread operator (`...e`) includes all original columns along with window fun
 interface PerformanceSchema {
   employees: { id: number; name: string; performance_score: number };
 }
-const perfContext = createSchema<PerformanceSchema>();
+const schema = createSchema<PerformanceSchema>();
 
 const topPerformers = await executeSelect(
   db,
-  perfContext,
+  schema,
   (q, params, helpers) =>
     q
       .from("employees")
@@ -3039,11 +3040,11 @@ Combine window function filters with regular WHERE conditions:
 interface ActiveEmployeeSchema {
   employees: { name: string; department: string; salary: number; is_active: boolean };
 }
-const activeEmpContext = createSchema<ActiveEmployeeSchema>();
+const schema = createSchema<ActiveEmployeeSchema>();
 
 const activeTopEarners = await executeSelect(
   db,
-  activeEmpContext,
+  schema,
   (q, params, helpers) =>
     q
       .from("employees")
@@ -3090,7 +3091,7 @@ Aggregate methods can be called directly on queries to return single values.
 const totals = selectStatement(
   schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .where((u) => u.active === true)
       .sum((u) => u.salary),
@@ -3115,7 +3116,7 @@ SELECT SUM("salary") FROM "users" WHERE "active" = @__p1
 Methods `count`, `average`, `min`, and `max` follow the same structure. The `count` method also accepts a predicate:
 
 ```typescript
-const activeCount = selectStatement(schema, (q) => ctx.from("users").count((u) => u.active), {});
+const activeCount = selectStatement(schema, (q) => q.from("users").count((u) => u.active), {});
 ```
 
 ```sql
@@ -3137,7 +3138,7 @@ Methods `any` and `all` test whether elements satisfy conditions.
 ### 10.1 Any Operation
 
 ```typescript
-const hasAdults = selectStatement(schema, (q) => ctx.from("users").any((u) => u.age >= 18), {});
+const hasAdults = selectStatement(schema, (q) => q.from("users").any((u) => u.age >= 18), {});
 ```
 
 ```sql
@@ -3161,7 +3162,7 @@ The `all` method emits a `NOT EXISTS` check:
 ```typescript
 const allActive = selectStatement(
   schema,
-  (q) => ctx.from("users").all((u) => u.active === true),
+  (q) => q.from("users").all((u) => u.active === true),
   {},
 );
 ```
@@ -3186,7 +3187,7 @@ Methods `first`, `firstOrDefault`, `single`, `singleOrDefault`, `last`, and `las
 const newestUser = selectStatement(
   schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .orderBy((u) => u.createdAt)
       .last(),
@@ -3219,7 +3220,7 @@ const activeUsers = await executeSelect(
   db,
   schema,
   (q) =>
-    ctx
+    q
       .from("users")
       .where((u) => u.active)
       .orderBy((u) => u.name),
@@ -3377,7 +3378,7 @@ const schema = createSchema<Schema>();
 const insert = insertStatement(
   schema,
   (q) =>
-    ctx.insertInto("users").values({
+    q.insertInto("users").values({
       name: "Alice",
       age: 30,
       email: "alice@example.com",
@@ -3434,7 +3435,7 @@ Both PostgreSQL and SQLite (3.35.0+) support the RETURNING clause to retrieve va
 const insertWithReturn = insertStatement(
   schema,
   (q) =>
-    ctx
+    q
       .insertInto("users")
       .values({ name: "Charlie", age: 35 })
       .returning((u) => ({ id: u.id, createdAt: u.createdAt })),
@@ -3445,7 +3446,7 @@ const insertWithReturn = insertStatement(
 const insertReturnAll = insertStatement(
   schema,
   (q) =>
-    ctx
+    q
       .insertInto("users")
       .values({ name: "David", age: 40 })
       .returning((u) => u), // Returns *
@@ -3459,7 +3460,7 @@ const insertReturnAll = insertStatement(
 const insert = insertStatement(
   schema,
   (q) =>
-    ctx.insertInto("users").values({
+    q.insertInto("users").values({
       name: "Eve",
       email: null, // Generates NULL, not parameterized
       phone: undefined, // Column omitted from INSERT
@@ -3483,7 +3484,7 @@ const schema = createSchema<Schema>();
 const updateStmt = updateStatement(
   schema,
   (q) =>
-    ctx
+    q
       .update("users")
       .set({ age: 31, lastModified: new Date() })
       .where((u) => u.id === 1),
@@ -3529,7 +3530,7 @@ const updateStmt = updateStatement(
 const updateStmt = updateStatement(
   schema,
   (q) =>
-    ctx
+    q
       .update("users")
       .set({ status: "inactive" })
       .where((u) => u.lastLogin < new Date("2023-01-01") && u.role !== "admin"),
@@ -3543,7 +3544,7 @@ const updateStmt = updateStatement(
 const updateWithReturn = updateStatement(
   schema,
   (q) =>
-    ctx
+    q
       .update("users")
       .set({ age: 32 })
       .where((u) => u.id === 2)
@@ -3558,7 +3559,7 @@ const updateWithReturn = updateStatement(
 // UPDATE without WHERE requires explicit permission
 const updateAll = updateStatement(
   schema,
-  (q) => ctx.update("users").set({ isActive: true }).allowFullTableUpdate(), // Required flag
+  (q) => q.update("users").set({ isActive: true }).allowFullTableUpdate(), // Required flag
   {},
 );
 ```
@@ -3582,7 +3583,7 @@ import { deleteStatement } from "@webpods/tinqer-sql-pg-promise";
 
 const schema = createSchema<Schema>();
 
-const del = deleteStatement(schema, (q) => ctx.deleteFrom("users").where((u) => u.age > 100), {});
+const del = deleteStatement(schema, (q) => q.deleteFrom("users").where((u) => u.age > 100), {});
 ```
 
 Generated SQL:
@@ -3598,7 +3599,7 @@ DELETE FROM "users" WHERE "age" > @__p1    -- SQLite
 const del = deleteStatement(
   schema,
   (q) =>
-    ctx
+    q
       .deleteFrom("users")
       .where((u) => u.isDeleted === true || (u.age < 18 && u.role !== "admin") || u.email === null),
   {},
@@ -3644,7 +3645,7 @@ WHERE "id" IN (@userIds_0, @userIds_1, @userIds_2, @userIds_3, @userIds_4)
 // DELETE without WHERE requires explicit permission
 const deleteAll = deleteStatement(
   schema,
-  (q) => ctx.deleteFrom("users").allowFullTableDelete(), // Required flag
+  (q) => q.deleteFrom("users").allowFullTableDelete(), // Required flag
   {},
 );
 ```
@@ -3659,11 +3660,11 @@ UPDATE and DELETE operations require WHERE clauses by default to prevent acciden
 
 ```typescript
 // This throws an error
-deleteStatement(schema, (q) => ctx.deleteFrom("users"), {});
+deleteStatement(schema, (q) => q.deleteFrom("users"), {});
 // Error: DELETE requires a WHERE clause or explicit allowFullTableDelete()
 
 // This works
-deleteStatement(schema, (q) => ctx.deleteFrom("users").allowFullTableDelete(), {});
+deleteStatement(schema, (q) => q.deleteFrom("users").allowFullTableDelete(), {});
 ```
 
 #### Type Safety
@@ -3674,13 +3675,13 @@ All CRUD operations maintain full TypeScript type safety:
 interface UserSchema {
   users: { id: number; name: string; email: string | null; age: number };
 }
-const userContext = createSchema<UserSchema>();
+const schema = createSchema<UserSchema>();
 
 // Type error: 'username' doesn't exist on users table
 insertStatement(
-  userContext,
+  schema,
   (q) =>
-    ctx.insertInto("users").values({
+    q.insertInto("users").values({
       username: "Alice", // ❌ Type error
     }),
   {},
@@ -3688,9 +3689,9 @@ insertStatement(
 
 // Type error: age must be number
 updateStatement(
-  userContext,
+  schema,
   (q) =>
-    ctx.update("users").set({
+    q.update("users").set({
       age: "30", // ❌ Type error - must be number
     }),
   {},
@@ -3704,9 +3705,9 @@ All values are automatically parameterized to prevent SQL injection:
 ```typescript
 const maliciousName = "'; DROP TABLE users; --";
 const insert = insertStatement(
-  userContext,
+  schema,
   (q) =>
-    ctx.insertInto("users").values({
+    q.insertInto("users").values({
       name: maliciousName, // Safely parameterized
     }),
   {},
@@ -3729,7 +3730,7 @@ const insertedUsers = await executeInsert(
   db,
   schema,
   (q) =>
-    ctx
+    q
       .insertInto("users")
       .values({ name: "Frank", age: 28 })
       .returning((u) => ({ id: u.id, name: u.name })),
@@ -3742,7 +3743,7 @@ const updateCount = await executeUpdate(
   db,
   schema,
   (q) =>
-    ctx
+    q
       .update("users")
       .set({ age: 29 })
       .where((u) => u.id === 123),
@@ -3754,7 +3755,7 @@ const updateCount = await executeUpdate(
 const deleteCount = await executeDelete(
   db,
   schema,
-  (q) => ctx.deleteFrom("users").where((u) => u.id === 123),
+  (q) => q.deleteFrom("users").where((u) => u.id === 123),
   {},
 );
 ```
@@ -3768,7 +3769,7 @@ import { executeInsert, executeUpdate, executeDelete } from "@webpods/tinqer-sql
 const insertCount = executeInsert(
   db,
   schema,
-  (q) => ctx.insertInto("users").values({ name: "Grace", age: 30 }),
+  (q) => q.insertInto("users").values({ name: "Grace", age: 30 }),
   {},
 );
 // Returns number of inserted rows
@@ -3778,7 +3779,7 @@ const updateCount = executeUpdate(
   db,
   schema,
   (q) =>
-    ctx
+    q
       .update("users")
       .set({ age: 33 })
       .where((u) => u.name === "Henry"),
@@ -3789,7 +3790,7 @@ const updateCount = executeUpdate(
 const deleteCount = executeDelete(
   db,
   schema,
-  (q) => ctx.deleteFrom("users").where((u) => u.age > 100),
+  (q) => q.deleteFrom("users").where((u) => u.age > 100),
   {},
 );
 ```
@@ -3805,15 +3806,15 @@ interface TxSchema {
   users: { id: number; name: string; lastLogin: Date };
   user_logs: { userId: number; action: string };
 }
-const txContext = createSchema<TxSchema>();
+const schema = createSchema<TxSchema>();
 
 // PostgreSQL transactions
 await db.tx(async (t) => {
   const users = await executeInsert(
     t,
-    txContext,
+    schema,
     (q) =>
-      ctx
+      q
         .insertInto("users")
         .values({ name: "Ivy" })
         .returning((u) => u.id),
@@ -3822,9 +3823,9 @@ await db.tx(async (t) => {
 
   await executeInsert(
     t,
-    txContext,
+    schema,
     (q) =>
-      ctx.insertInto("user_logs").values({
+      q.insertInto("user_logs").values({
         userId: users[0]!.id,
         action: "created",
       }),
@@ -3834,12 +3835,12 @@ await db.tx(async (t) => {
 
 // SQLite transactions
 const transaction = sqliteDb.transaction(() => {
-  executeInsert(db, txContext, (q) => ctx.insertInto("users").values({ name: "Jack" }), {});
+  executeInsert(db, schema, (q) => q.insertInto("users").values({ name: "Jack" }), {});
   executeUpdate(
     db,
-    txContext,
+    schema,
     (q) =>
-      ctx
+      q
         .update("users")
         .set({ lastLogin: new Date() })
         .where((u) => u.name === "Jack"),


### PR DESCRIPTION
Regenerate website to include all documentation fixes from tinqer repo:
- Fixed 120+ ctx→q parameter bugs
- Standardized schema variable names
- Fixed missing params in examples
- Fixed incorrect anchor links
- Updated llms.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)