### PR TITLE
chore: update documentation from tinqer 0.0.20

### DIFF
--- a/build/adapters.html
+++ b/build/adapters.html
@@ -90,13 +90,19 @@
 </code></pre>
 <h3 id="12-setup-%26-query-execution" tabindex="-1"><a class="anchor" href="#12-setup-%26-query-execution" aria-hidden="true">#</a> 1.2 Setup &amp; Query Execution</h3>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> pgPromise <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;pg-promise&quot;</span>;
-<span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> {
+  createSchema,
+  defineSelect,
+  defineInsert,
+  defineUpdate,
+  defineDelete,
+} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> {
   executeSelect,
   executeInsert,
   executeUpdate,
   executeDelete,
-  selectStatement,
+  toSql,
 } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -110,70 +116,68 @@
 <span class="hljs-comment">// Execute with params</span>
 <span class="hljs-keyword">const</span> activeUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span> &amp;&amp; u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
+  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 
 <span class="hljs-comment">// Execute with params</span>
 <span class="hljs-keyword">const</span> matchingUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
+  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">21</span> },
 );
 
 <span class="hljs-comment">// INSERT with RETURNING</span>
 <span class="hljs-keyword">const</span> createdUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Alice&quot;</span>, <span class="hljs-attr">email</span>: <span class="hljs-string">&quot;alice@example.com&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">30</span>, <span class="hljs-attr">active</span>: <span class="hljs-literal">true</span> })
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">createdAt</span>: u.<span class="hljs-property">createdAt</span> })),
+  ),
   {},
 );
 
 <span class="hljs-comment">// UPDATE</span>
 <span class="hljs-keyword">const</span> updatedCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeUpdate</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">active</span>: <span class="hljs-literal">false</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">65</span>),
+  ),
   {},
 );
 
 <span class="hljs-comment">// DELETE</span>
 <span class="hljs-keyword">const</span> deletedCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeDelete</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> !u.<span class="hljs-property">active</span>),
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> !u.<span class="hljs-property">active</span>)),
   {},
 );
 
 <span class="hljs-comment">// Generate SQL without executing</span>
-<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">email</span>.<span class="hljs-title function_">endsWith</span>(<span class="hljs-string">&quot;@example.com&quot;</span>)),
+<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">email</span>.<span class="hljs-title function_">endsWith</span>(<span class="hljs-string">&quot;@example.com&quot;</span>))),
   {},
 );
 </code></pre>
 <h3 id="13-postgresql-dialect-notes" tabindex="-1"><a class="anchor" href="#13-postgresql-dialect-notes" aria-hidden="true">#</a> 1.3 PostgreSQL Dialect Notes</h3>
 <ul>
 <li>Booleans map to <code>BOOLEAN</code> values (<code>true</code>/<code>false</code>).</li>
-<li>Case-insensitive comparisons use <code>ILIKE</code> when you call helper functions such as <code>contains</code>.</li>
+<li>Case-insensitive helper functions generate <code>LOWER()</code> comparisons for portable SQL.</li>
 <li>RETURNING clauses are fully supported on INSERT, UPDATE, and DELETE through the execution helpers.</li>
 <li>Parameter placeholders use the <code>$()</code> syntax expected by pg-promise (e.g., <code>$(minAge)</code>).</li>
 <li>Window functions (<code>ROW_NUMBER()</code>, <code>RANK()</code>, <code>DENSE_RANK()</code>) are fully supported.</li>
@@ -185,13 +189,19 @@
 </code></pre>
 <h3 id="22-setup-%26-query-execution" tabindex="-1"><a class="anchor" href="#22-setup-%26-query-execution" aria-hidden="true">#</a> 2.2 Setup &amp; Query Execution</h3>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> <span class="hljs-title class_">Database</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;better-sqlite3&quot;</span>;
-<span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> {
+  createSchema,
+  defineSelect,
+  defineInsert,
+  defineUpdate,
+  defineDelete,
+} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> {
   executeSelect,
   executeInsert,
   executeUpdate,
   executeDelete,
-  selectStatement,
+  toSql,
 } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-better-sqlite3&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -213,45 +223,46 @@ db.<span class="hljs-title function_">exec</span>(<span class="hljs-string">`
 
 <span class="hljs-keyword">const</span> inserted = <span class="hljs-title function_">executeInsert</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Sam&quot;</span>, <span class="hljs-attr">email</span>: <span class="hljs-string">&quot;sam@example.com&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">28</span> }),
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+    q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Sam&quot;</span>, <span class="hljs-attr">email</span>: <span class="hljs-string">&quot;sam@example.com&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">28</span> }),
+  ),
   {},
 );
 <span class="hljs-comment">// inserted === 1</span>
 
 <span class="hljs-keyword">const</span> users = <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { active: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">isActive</span> === params.<span class="hljs-property">active</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
+  ),
   { <span class="hljs-attr">active</span>: <span class="hljs-number">1</span> },
 );
 
 <span class="hljs-keyword">const</span> updated = <span class="hljs-title function_">executeUpdate</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">isActive</span>: <span class="hljs-number">0</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">60</span>),
+  ),
   {},
 );
 
 <span class="hljs-keyword">const</span> removed = <span class="hljs-title function_">executeDelete</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt; params.<span class="hljs-property">cutoff</span>),
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoff: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+    q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt; params.<span class="hljs-property">cutoff</span>),
+  ),
   { <span class="hljs-attr">cutoff</span>: <span class="hljs-number">18</span> },
 );
 
 <span class="hljs-comment">// Need the SQL text for custom execution?</span>
-<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>.<span class="hljs-title function_">startsWith</span>(<span class="hljs-string">&quot;S&quot;</span>)),
+<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>.<span class="hljs-title function_">startsWith</span>(<span class="hljs-string">&quot;S&quot;</span>))),
   {},
 );
 <span class="hljs-keyword">const</span> rows = db.<span class="hljs-title function_">prepare</span>(sql).<span class="hljs-title function_">all</span>(params);
@@ -338,8 +349,8 @@ db.<span class="hljs-title function_">exec</span>(<span class="hljs-string">`
 </table>
 <h3 id="33-case-insensitive-matching" tabindex="-1"><a class="anchor" href="#33-case-insensitive-matching" aria-hidden="true">#</a> 3.3 Case-Insensitive Matching</h3>
 <p>Use query helpers for portable case-insensitive comparisons:</p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { selectStatement } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">email</span>: <span class="hljs-built_in">string</span> };
@@ -347,13 +358,13 @@ db.<span class="hljs-title function_">exec</span>(<span class="hljs-string">`
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-keyword">const</span> { sql } = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> { sql } = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> helpers.<span class="hljs-property">functions</span>.<span class="hljs-title function_">icontains</span>(u.<span class="hljs-property">name</span>, <span class="hljs-string">&quot;alice&quot;</span>)),
+  ),
   {},
 );
-<span class="hljs-comment">// PostgreSQL: WHERE &quot;name&quot; ILIKE $(__p1)</span>
+<span class="hljs-comment">// PostgreSQL: WHERE LOWER(&quot;name&quot;) LIKE &#x27;%&#x27; || LOWER($(__p1)) || &#x27;%&#x27;</span>
 <span class="hljs-comment">// SQLite: WHERE LOWER(&quot;name&quot;) LIKE &#x27;%&#x27; || LOWER(@__p1) || &#x27;%&#x27;</span>
 </code></pre>
 <h3 id="34-returning-behaviour" tabindex="-1"><a class="anchor" href="#34-returning-behaviour" aria-hidden="true">#</a> 3.4 RETURNING Behaviour</h3>

--- a/build/api-reference.html
+++ b/build/api-reference.html
@@ -62,13 +62,11 @@
 <ul>
 <li><a href="#1-execution-apis">1. Execution APIs</a>
 <ul>
-<li><a href="#11-selectstatement">1.1 selectStatement</a></li>
-<li><a href="#12-executeselect">1.2 executeSelect</a></li>
-<li><a href="#13-insertstatement--executeinsert">1.3 insertStatement &amp; executeInsert</a></li>
-<li><a href="#14-updatestatement--executeupdate">1.4 updateStatement &amp; executeUpdate</a></li>
-<li><a href="#15-deletestatement--executedelete">1.5 deleteStatement &amp; executeDelete</a></li>
-<li><a href="#16-tosql">1.6 toSql</a></li>
-<li><a href="#17-executeoptions--sqlresult">1.7 ExecuteOptions &amp; SqlResult</a></li>
+<li><a href="#11-defineselect-tosql--executeselect">1.1 defineSelect, toSql &amp; executeSelect</a></li>
+<li><a href="#12-defineinsert-tosql--executeinsert">1.2 defineInsert, toSql &amp; executeInsert</a></li>
+<li><a href="#13-defineupdate-tosql--executeupdate">1.3 defineUpdate, toSql &amp; executeUpdate</a></li>
+<li><a href="#14-definedelete-tosql--executedelete">1.4 defineDelete, toSql &amp; executeDelete</a></li>
+<li><a href="#15-executeoptions--sqlresult">1.5 ExecuteOptions &amp; SqlResult</a></li>
 </ul>
 </li>
 <li><a href="#2-type-safe-contexts">2. Type-Safe Contexts</a>
@@ -84,23 +82,43 @@
 </ul>
 <hr>
 <h2 id="1-execution-apis" tabindex="-1"><a class="anchor" href="#1-execution-apis" aria-hidden="true">#</a> 1. Execution APIs</h2>
-<p>Adapter packages export the runtime helpers that turn expression trees into SQL and execute them. PostgreSQL helpers live in <code>@webpods/tinqer-sql-pg-promise</code>; SQLite helpers live in <code>@webpods/tinqer-sql-better-sqlite3</code> and expose the same signatures.</p>
-<h3 id="11-selectstatement" tabindex="-1"><a class="anchor" href="#11-selectstatement" aria-hidden="true">#</a> 1.1 selectStatement</h3>
-<p>Converts a query builder function into SQL and named parameters without executing it. The query builder receives a DSL context, parameters, and helper functions.</p>
-<p><strong>Signature</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">function</span> selectStatement&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TResult</span>&gt;(
+<p>Tinqer uses a two-step API:</p>
+<ol>
+<li><strong>Plan definition</strong> (<code>define*</code> functions from <code>@webpods/tinqer</code>) - Creates type-safe query plans</li>
+<li><strong>Execution or SQL generation</strong> (<code>execute*</code> or <code>toSql</code> from adapter packages) - Executes plans or generates SQL</li>
+</ol>
+<p>Adapter packages live in <code>@webpods/tinqer-sql-pg-promise</code> (PostgreSQL) and <code>@webpods/tinqer-sql-better-sqlite3</code> (SQLite).</p>
+<h3 id="11-defineselect%2C-tosql-%26-executeselect" tabindex="-1"><a class="anchor" href="#11-defineselect%2C-tosql-%26-executeselect" aria-hidden="true">#</a> 1.1 defineSelect, toSql &amp; executeSelect</h3>
+<p>Creates SELECT query plans, generates SQL, or executes queries.</p>
+<p><strong>Signatures</strong></p>
+<pre class="hljs"><code><span class="hljs-comment">// Plan definition (from @webpods/tinqer)</span>
+<span class="hljs-keyword">function</span> defineSelect&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TResult</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
   <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
-    <span class="hljs-attr">ctx</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
+    <span class="hljs-attr">q</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
     <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
     <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">QueryHelpers</span>,
   </span>) =&gt;</span> <span class="hljs-title class_">Queryable</span>&lt;<span class="hljs-title class_">TResult</span>&gt; | <span class="hljs-title class_">OrderedQueryable</span>&lt;<span class="hljs-title class_">TResult</span>&gt; | <span class="hljs-title class_">TerminalQuery</span>&lt;<span class="hljs-title class_">TResult</span>&gt;,
+  <span class="hljs-attr">paramDefaults</span>?: <span class="hljs-title class_">TParams</span>,
+): <span class="hljs-title class_">SelectPlanHandle</span>&lt;<span class="hljs-title class_">TResult</span>, <span class="hljs-title class_">TParams</span>&gt; | <span class="hljs-title class_">SelectTerminalHandle</span>&lt;<span class="hljs-title class_">TResult</span>, <span class="hljs-title class_">TParams</span>&gt;;
+
+<span class="hljs-comment">// SQL generation (from adapter packages)</span>
+<span class="hljs-keyword">function</span> toSql&lt;<span class="hljs-title class_">TParams</span>&gt;(
+  <span class="hljs-attr">plan</span>: <span class="hljs-title class_">SelectPlanHandle</span>&lt;<span class="hljs-built_in">unknown</span>, <span class="hljs-title class_">TParams</span>&gt; | <span class="hljs-title class_">SelectTerminalHandle</span>&lt;<span class="hljs-built_in">unknown</span>, <span class="hljs-title class_">TParams</span>&gt;,
   <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-): <span class="hljs-title class_">SqlResult</span>&lt;<span class="hljs-title class_">TParams</span> &amp; <span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt;, <span class="hljs-title class_">TResult</span>&gt;;
+): { <span class="hljs-attr">sql</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span> &amp; <span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt; };
+
+<span class="hljs-comment">// Execution (from adapter packages)</span>
+<span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeSelect&lt;<span class="hljs-title class_">TResult</span>, <span class="hljs-title class_">TParams</span>&gt;(
+  <span class="hljs-attr">db</span>: <span class="hljs-title class_">PgDatabase</span> | <span class="hljs-title class_">BetterSqlite3Database</span>,
+  <span class="hljs-attr">plan</span>: <span class="hljs-title class_">SelectPlanHandle</span>&lt;<span class="hljs-title class_">TResult</span>, <span class="hljs-title class_">TParams</span>&gt; | <span class="hljs-title class_">SelectTerminalHandle</span>&lt;<span class="hljs-title class_">TResult</span>, <span class="hljs-title class_">TParams</span>&gt;,
+  <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
+  <span class="hljs-attr">options</span>?: <span class="hljs-title class_">ExecuteOptions</span>,
+): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-title class_">TResult</span>[] | <span class="hljs-title class_">TResult</span>&gt;;
 </code></pre>
-<p><strong>Example (PostgreSQL)</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { selectStatement } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<p><strong>Example - SQL Generation</strong></p>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span> };
@@ -108,42 +126,20 @@
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
+  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 <span class="hljs-comment">// sql: SELECT &quot;id&quot; AS &quot;id&quot;, &quot;name&quot; AS &quot;name&quot; FROM &quot;users&quot; WHERE &quot;age&quot; &gt;= $(minAge)</span>
 <span class="hljs-comment">// params: { minAge: 18 }</span>
 </code></pre>
-<h3 id="12-executeselect" tabindex="-1"><a class="anchor" href="#12-executeselect" aria-hidden="true">#</a> 1.2 executeSelect</h3>
-<p>Executes a query builder against the database and returns typed results. The query builder receives a DSL context, parameters, and helper functions.</p>
-<pre class="hljs"><code><span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeSelect&lt;
-  <span class="hljs-title class_">TSchema</span>,
-  <span class="hljs-title class_">TParams</span>,
-  <span class="hljs-title class_">TQuery</span> <span class="hljs-keyword">extends</span> <span class="hljs-title class_">Queryable</span>&lt;<span class="hljs-built_in">unknown</span>&gt; | <span class="hljs-title class_">OrderedQueryable</span>&lt;<span class="hljs-built_in">unknown</span>&gt; | <span class="hljs-title class_">TerminalQuery</span>&lt;<span class="hljs-built_in">unknown</span>&gt;,
-&gt;(
-  <span class="hljs-attr">db</span>: <span class="hljs-title class_">PgDatabase</span> | <span class="hljs-title class_">BetterSqlite3Database</span>,
-  <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-  <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params"><span class="hljs-attr">ctx</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;, <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>, <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">QueryHelpers</span></span>) =&gt;</span> <span class="hljs-title class_">TQuery</span>,
-  <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-  <span class="hljs-attr">options</span>?: <span class="hljs-title class_">ExecuteOptions</span>,
-): <span class="hljs-title class_">Promise</span>&lt;
-  <span class="hljs-title class_">TQuery</span> <span class="hljs-keyword">extends</span> <span class="hljs-title class_">Queryable</span>&lt;infer T&gt;
-    ? T[]
-    : <span class="hljs-title class_">TQuery</span> <span class="hljs-keyword">extends</span> <span class="hljs-title class_">OrderedQueryable</span>&lt;infer T&gt;
-      ? T[]
-      : <span class="hljs-title class_">TQuery</span> <span class="hljs-keyword">extends</span> <span class="hljs-title class_">TerminalQuery</span>&lt;infer T&gt;
-        ? T
-        : <span class="hljs-built_in">never</span>
-&gt;;
-</code></pre>
-<p><strong>Example (PostgreSQL)</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<p><strong>Example - Execution</strong></p>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -154,53 +150,65 @@
 
 <span class="hljs-keyword">const</span> users = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
+  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">21</span> },
 );
+<span class="hljs-comment">// Returns: Array of user objects</span>
 </code></pre>
-<h3 id="13-insertstatement-%26-executeinsert" tabindex="-1"><a class="anchor" href="#13-insertstatement-%26-executeinsert" aria-hidden="true">#</a> 1.3 insertStatement &amp; executeInsert</h3>
-<p>Generate and execute INSERT statements with optional RETURNING clauses. The query builder receives a DSL context, parameters, and helper functions.</p>
-<pre class="hljs"><code><span class="hljs-keyword">function</span> insertStatement&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span> = <span class="hljs-built_in">never</span>&gt;(
+<h3 id="12-defineinsert%2C-tosql-%26-executeinsert" tabindex="-1"><a class="anchor" href="#12-defineinsert%2C-tosql-%26-executeinsert" aria-hidden="true">#</a> 1.2 defineInsert, toSql &amp; executeInsert</h3>
+<p>Creates INSERT query plans, generates SQL, or executes queries with optional RETURNING clauses.</p>
+<p><strong>Signatures</strong></p>
+<pre class="hljs"><code><span class="hljs-comment">// Plan definition (from @webpods/tinqer)</span>
+<span class="hljs-keyword">function</span> defineInsert&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span> = <span class="hljs-built_in">never</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
   <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
-    <span class="hljs-attr">ctx</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
+    <span class="hljs-attr">q</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
     <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
     <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">QueryHelpers</span>,
   </span>) =&gt;</span> <span class="hljs-title class_">Insertable</span>&lt;<span class="hljs-title class_">TTable</span>&gt; | <span class="hljs-title class_">InsertableWithReturning</span>&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>&gt;,
-  <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-): <span class="hljs-title class_">SqlResult</span>&lt;<span class="hljs-title class_">TParams</span> &amp; <span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt;, <span class="hljs-title class_">TReturning</span> <span class="hljs-keyword">extends</span> <span class="hljs-built_in">never</span> ? <span class="hljs-built_in">void</span> : <span class="hljs-title class_">TReturning</span>&gt;;
+  <span class="hljs-attr">paramDefaults</span>?: <span class="hljs-title class_">TParams</span>,
+): <span class="hljs-title class_">InsertPlanHandle</span>&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>, <span class="hljs-title class_">TParams</span>&gt;;
 
-<span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeInsert&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>&gt;(
+<span class="hljs-comment">// SQL generation (from adapter packages)</span>
+<span class="hljs-keyword">function</span> toSql&lt;<span class="hljs-title class_">TParams</span>&gt;(
+  <span class="hljs-attr">plan</span>: <span class="hljs-title class_">InsertPlanHandle</span>&lt;<span class="hljs-built_in">unknown</span>, <span class="hljs-built_in">unknown</span>, <span class="hljs-title class_">TParams</span>&gt;,
+  <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
+): { <span class="hljs-attr">sql</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span> &amp; <span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt; };
+
+<span class="hljs-comment">// Execution (from adapter packages)</span>
+<span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeInsert&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>, <span class="hljs-title class_">TParams</span>&gt;(
   <span class="hljs-attr">db</span>: <span class="hljs-title class_">PgDatabase</span> | <span class="hljs-title class_">BetterSqlite3Database</span>,
-  <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-  <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
-    <span class="hljs-attr">ctx</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-    <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-    <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">QueryHelpers</span>,
-  </span>) =&gt;</span> <span class="hljs-title class_">Insertable</span>&lt;<span class="hljs-title class_">TTable</span>&gt;,
+  <span class="hljs-attr">plan</span>: <span class="hljs-title class_">InsertPlanHandle</span>&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>, <span class="hljs-title class_">TParams</span>&gt;,
   <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
   <span class="hljs-attr">options</span>?: <span class="hljs-title class_">ExecuteOptions</span>,
-): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-built_in">number</span>&gt;;
-
-<span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeInsert&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>&gt;(
-  <span class="hljs-attr">db</span>: <span class="hljs-title class_">PgDatabase</span> | <span class="hljs-title class_">BetterSqlite3Database</span>,
-  <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-  <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
-    <span class="hljs-attr">ctx</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-    <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-    <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">QueryHelpers</span>,
-  </span>) =&gt;</span> <span class="hljs-title class_">InsertableWithReturning</span>&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>&gt;,
-  <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-  <span class="hljs-attr">options</span>?: <span class="hljs-title class_">ExecuteOptions</span>,
-): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-title class_">TReturning</span>[]&gt;;
+): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-title class_">TReturning</span> <span class="hljs-keyword">extends</span> <span class="hljs-built_in">never</span> ? <span class="hljs-built_in">number</span> : <span class="hljs-title class_">TReturning</span>[]&gt;;
 </code></pre>
-<p><strong>Example</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<p><strong>Example - SQL Generation</strong></p>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+
+<span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
+  <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span> };
+}
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
+
+<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { name: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
+    q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: params.<span class="hljs-property">name</span> }),
+  ),
+  { <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Alice&quot;</span> },
+);
+<span class="hljs-comment">// sql: INSERT INTO &quot;users&quot; (&quot;name&quot;) VALUES ($(name))</span>
+<span class="hljs-comment">// params: { name: &quot;Alice&quot; }</span>
+</code></pre>
+<p><strong>Example - Execution</strong></p>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeInsert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -209,65 +217,82 @@
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-keyword">const</span> inserted = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
+<span class="hljs-comment">// Without RETURNING - returns number of rows inserted</span>
+<span class="hljs-keyword">const</span> rowCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Alice&quot;</span> }),
-  {},
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { name: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
+    q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: params.<span class="hljs-property">name</span> }),
+  ),
+  { <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Alice&quot;</span> },
 );
 
+<span class="hljs-comment">// With RETURNING - returns inserted rows</span>
 <span class="hljs-keyword">const</span> createdUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { name: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
-      .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Bob&quot;</span> })
+      .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: params.<span class="hljs-property">name</span> })
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
-  {},
+  ),
+  { <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Bob&quot;</span> },
 );
 </code></pre>
-<h3 id="14-updatestatement-%26-executeupdate" tabindex="-1"><a class="anchor" href="#14-updatestatement-%26-executeupdate" aria-hidden="true">#</a> 1.4 updateStatement &amp; executeUpdate</h3>
-<p>Generate and execute UPDATE statements with optional RETURNING clauses. The query builder receives a DSL context, parameters, and helper functions.</p>
-<pre class="hljs"><code><span class="hljs-keyword">function</span> updateStatement&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span> = <span class="hljs-built_in">never</span>&gt;(
+<h3 id="13-defineupdate%2C-tosql-%26-executeupdate" tabindex="-1"><a class="anchor" href="#13-defineupdate%2C-tosql-%26-executeupdate" aria-hidden="true">#</a> 1.3 defineUpdate, toSql &amp; executeUpdate</h3>
+<p>Creates UPDATE query plans, generates SQL, or executes queries with optional RETURNING clauses.</p>
+<p><strong>Signatures</strong></p>
+<pre class="hljs"><code><span class="hljs-comment">// Plan definition (from @webpods/tinqer)</span>
+<span class="hljs-keyword">function</span> defineUpdate&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span> = <span class="hljs-built_in">never</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
   <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
-    <span class="hljs-attr">ctx</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
+    <span class="hljs-attr">q</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
     <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
     <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">QueryHelpers</span>,
   </span>) =&gt;</span>
     | <span class="hljs-title class_">UpdatableWithSet</span>&lt;<span class="hljs-title class_">TTable</span>&gt;
     | <span class="hljs-title class_">UpdatableComplete</span>&lt;<span class="hljs-title class_">TTable</span>&gt;
     | <span class="hljs-title class_">UpdatableWithReturning</span>&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>&gt;,
-  <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-): <span class="hljs-title class_">SqlResult</span>&lt;<span class="hljs-title class_">TParams</span> &amp; <span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt;, <span class="hljs-title class_">TReturning</span> <span class="hljs-keyword">extends</span> <span class="hljs-built_in">never</span> ? <span class="hljs-built_in">void</span> : <span class="hljs-title class_">TReturning</span>&gt;;
+  <span class="hljs-attr">paramDefaults</span>?: <span class="hljs-title class_">TParams</span>,
+): <span class="hljs-title class_">UpdatePlanHandle</span>&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>, <span class="hljs-title class_">TParams</span>&gt;;
 
-<span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeUpdate&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>&gt;(
+<span class="hljs-comment">// SQL generation (from adapter packages)</span>
+<span class="hljs-keyword">function</span> toSql&lt;<span class="hljs-title class_">TParams</span>&gt;(
+  <span class="hljs-attr">plan</span>: <span class="hljs-title class_">UpdatePlanHandle</span>&lt;<span class="hljs-built_in">unknown</span>, <span class="hljs-built_in">unknown</span>, <span class="hljs-title class_">TParams</span>&gt;,
+  <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
+): { <span class="hljs-attr">sql</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span> &amp; <span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt; };
+
+<span class="hljs-comment">// Execution (from adapter packages)</span>
+<span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeUpdate&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>, <span class="hljs-title class_">TParams</span>&gt;(
   <span class="hljs-attr">db</span>: <span class="hljs-title class_">PgDatabase</span> | <span class="hljs-title class_">BetterSqlite3Database</span>,
-  <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-  <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
-    <span class="hljs-attr">ctx</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-    <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-    <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">QueryHelpers</span>,
-  </span>) =&gt;</span> <span class="hljs-title class_">UpdatableWithSet</span>&lt;<span class="hljs-title class_">TTable</span>&gt; | <span class="hljs-title class_">UpdatableComplete</span>&lt;<span class="hljs-title class_">TTable</span>&gt;,
+  <span class="hljs-attr">plan</span>: <span class="hljs-title class_">UpdatePlanHandle</span>&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>, <span class="hljs-title class_">TParams</span>&gt;,
   <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
   <span class="hljs-attr">options</span>?: <span class="hljs-title class_">ExecuteOptions</span>,
-): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-built_in">number</span>&gt;;
-
-<span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeUpdate&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>&gt;(
-  <span class="hljs-attr">db</span>: <span class="hljs-title class_">PgDatabase</span> | <span class="hljs-title class_">BetterSqlite3Database</span>,
-  <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-  <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
-    <span class="hljs-attr">ctx</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-    <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-    <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">QueryHelpers</span>,
-  </span>) =&gt;</span> <span class="hljs-title class_">UpdatableWithReturning</span>&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>&gt;,
-  <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-  <span class="hljs-attr">options</span>?: <span class="hljs-title class_">ExecuteOptions</span>,
-): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-title class_">TReturning</span>[]&gt;;
+): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-title class_">TReturning</span> <span class="hljs-keyword">extends</span> <span class="hljs-built_in">never</span> ? <span class="hljs-built_in">number</span> : <span class="hljs-title class_">TReturning</span>[]&gt;;
 </code></pre>
-<p><strong>Example</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<p><strong>Example - SQL Generation</strong></p>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineUpdate } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+
+<span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
+  <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">status</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">lastLogin</span>: <span class="hljs-title class_">Date</span> };
+}
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
+
+<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoff: <span class="hljs-built_in">Date</span> }</span>) =&gt;</span>
+    q
+      .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
+      .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> })
+      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">lastLogin</span> &lt; params.<span class="hljs-property">cutoff</span>),
+  ),
+  { <span class="hljs-attr">cutoff</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>(<span class="hljs-string">&quot;2024-01-01&quot;</span>) },
+);
+<span class="hljs-comment">// sql: UPDATE &quot;users&quot; SET &quot;status&quot; = &#x27;inactive&#x27; WHERE &quot;lastLogin&quot; &lt; $(cutoff)</span>
+<span class="hljs-comment">// params: { cutoff: Date }</span>
+</code></pre>
+<p><strong>Example - Execution</strong></p>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineUpdate } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeUpdate } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -276,43 +301,80 @@
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
+<span class="hljs-comment">// Without RETURNING - returns number of rows updated</span>
 <span class="hljs-keyword">const</span> updatedRows = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeUpdate</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoff: <span class="hljs-built_in">Date</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">lastLogin</span> &lt; params.<span class="hljs-property">cutoff</span>),
+  ),
+  { <span class="hljs-attr">cutoff</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>(<span class="hljs-string">&quot;2024-01-01&quot;</span>) },
+);
+
+<span class="hljs-comment">// With RETURNING - returns updated rows</span>
+<span class="hljs-keyword">const</span> updatedUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeUpdate</span>(
+  db,
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoff: <span class="hljs-built_in">Date</span> }</span>) =&gt;</span>
+    q
+      .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
+      .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> })
+      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">lastLogin</span> &lt; params.<span class="hljs-property">cutoff</span>)
+      .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">status</span>: u.<span class="hljs-property">status</span> })),
+  ),
   { <span class="hljs-attr">cutoff</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>(<span class="hljs-string">&quot;2024-01-01&quot;</span>) },
 );
 </code></pre>
-<h3 id="15-deletestatement-%26-executedelete" tabindex="-1"><a class="anchor" href="#15-deletestatement-%26-executedelete" aria-hidden="true">#</a> 1.5 deleteStatement &amp; executeDelete</h3>
-<p>Generate and execute DELETE statements. The query builder receives a DSL context, parameters, and helper functions.</p>
-<pre class="hljs"><code><span class="hljs-keyword">function</span> deleteStatement&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TResult</span>&gt;(
+<h3 id="14-definedelete%2C-tosql-%26-executedelete" tabindex="-1"><a class="anchor" href="#14-definedelete%2C-tosql-%26-executedelete" aria-hidden="true">#</a> 1.4 defineDelete, toSql &amp; executeDelete</h3>
+<p>Creates DELETE query plans, generates SQL, or executes queries.</p>
+<p><strong>Signatures</strong></p>
+<pre class="hljs"><code><span class="hljs-comment">// Plan definition (from @webpods/tinqer)</span>
+<span class="hljs-keyword">function</span> defineDelete&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
   <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
-    <span class="hljs-attr">ctx</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
+    <span class="hljs-attr">q</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
     <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
     <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">QueryHelpers</span>,
-  </span>) =&gt;</span> <span class="hljs-title class_">Deletable</span>&lt;<span class="hljs-title class_">TResult</span>&gt; | <span class="hljs-title class_">DeletableComplete</span>&lt;<span class="hljs-title class_">TResult</span>&gt;,
-  <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-): <span class="hljs-title class_">SqlResult</span>&lt;<span class="hljs-title class_">TParams</span> &amp; <span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt;, <span class="hljs-built_in">void</span>&gt;;
+  </span>) =&gt;</span> <span class="hljs-title class_">Deletable</span>&lt;<span class="hljs-built_in">unknown</span>&gt; | <span class="hljs-title class_">DeletableComplete</span>&lt;<span class="hljs-built_in">unknown</span>&gt;,
+  <span class="hljs-attr">paramDefaults</span>?: <span class="hljs-title class_">TParams</span>,
+): <span class="hljs-title class_">DeletePlanHandle</span>&lt;<span class="hljs-title class_">TParams</span>&gt;;
 
-<span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeDelete&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TResult</span>&gt;(
+<span class="hljs-comment">// SQL generation (from adapter packages)</span>
+<span class="hljs-keyword">function</span> toSql&lt;<span class="hljs-title class_">TParams</span>&gt;(
+  <span class="hljs-attr">plan</span>: <span class="hljs-title class_">DeletePlanHandle</span>&lt;<span class="hljs-title class_">TParams</span>&gt;,
+  <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
+): { <span class="hljs-attr">sql</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span> &amp; <span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt; };
+
+<span class="hljs-comment">// Execution (from adapter packages)</span>
+<span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeDelete&lt;<span class="hljs-title class_">TParams</span>&gt;(
   <span class="hljs-attr">db</span>: <span class="hljs-title class_">PgDatabase</span> | <span class="hljs-title class_">BetterSqlite3Database</span>,
-  <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-  <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
-    <span class="hljs-attr">ctx</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-    <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-    <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">QueryHelpers</span>,
-  </span>) =&gt;</span> <span class="hljs-title class_">Deletable</span>&lt;<span class="hljs-title class_">TResult</span>&gt; | <span class="hljs-title class_">DeletableComplete</span>&lt;<span class="hljs-title class_">TResult</span>&gt;,
+  <span class="hljs-attr">plan</span>: <span class="hljs-title class_">DeletePlanHandle</span>&lt;<span class="hljs-title class_">TParams</span>&gt;,
   <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
   <span class="hljs-attr">options</span>?: <span class="hljs-title class_">ExecuteOptions</span>,
 ): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-built_in">number</span>&gt;;
 </code></pre>
-<p><strong>Example</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<p><strong>Example - SQL Generation</strong></p>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+
+<span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
+  <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">status</span>: <span class="hljs-built_in">string</span> };
+}
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
+
+<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { status: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
+    q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">status</span> === params.<span class="hljs-property">status</span>),
+  ),
+  { <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> },
+);
+<span class="hljs-comment">// sql: DELETE FROM &quot;users&quot; WHERE &quot;status&quot; = $(status)</span>
+<span class="hljs-comment">// params: { status: &quot;inactive&quot; }</span>
+</code></pre>
+<p><strong>Example - Execution</strong></p>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -323,40 +385,13 @@
 
 <span class="hljs-keyword">const</span> deletedCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeDelete</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">status</span> === <span class="hljs-string">&quot;inactive&quot;</span>),
-  {},
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { status: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
+    q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">status</span> === params.<span class="hljs-property">status</span>),
+  ),
+  { <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> },
 );
 </code></pre>
-<h3 id="16-statement-functions-(selectstatement%2C-insertstatement%2C-etc)" tabindex="-1"><a class="anchor" href="#16-statement-functions-(selectstatement%2C-insertstatement%2C-etc)" aria-hidden="true">#</a> 1.6 Statement Functions (selectStatement, insertStatement, etc.)</h3>
-<p>Generate SQL and parameters without executing them. These functions are useful for debugging, testing, or when you need the SQL before execution.</p>
-<pre class="hljs"><code><span class="hljs-keyword">function</span> selectStatement&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TResult</span>&gt;(
-  <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-  <span class="hljs-attr">builder</span>: <span class="hljs-function">(<span class="hljs-params"><span class="hljs-attr">q</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;</span>) =&gt;</span> <span class="hljs-title class_">Queryable</span>&lt;<span class="hljs-title class_">TResult</span>&gt;,
-): <span class="hljs-title class_">SqlResult</span>&lt;<span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt;, <span class="hljs-title class_">TResult</span>&gt;;
-</code></pre>
-<p><strong>Example (SQLite)</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { selectStatement } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-better-sqlite3&quot;</span>;
-
-<span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
-  <span class="hljs-attr">products</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">price</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">inStock</span>: <span class="hljs-built_in">number</span> };
-}
-
-<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
-
-<span class="hljs-comment">// Generate SQL without executing</span>
-<span class="hljs-keyword">const</span> result = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-  q
-    .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;products&quot;</span>)
-    .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> p.<span class="hljs-property">inStock</span> === <span class="hljs-number">1</span>)
-    .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> p.<span class="hljs-property">price</span>),
-);
-
-<span class="hljs-comment">// result.sql contains the SQL string</span>
-<span class="hljs-comment">// result.params contains the parameters</span>
-</code></pre>
-<h3 id="17-executeoptions-%26-sqlresult" tabindex="-1"><a class="anchor" href="#17-executeoptions-%26-sqlresult" aria-hidden="true">#</a> 1.7 ExecuteOptions &amp; SqlResult</h3>
+<h3 id="15-executeoptions-%26-sqlresult" tabindex="-1"><a class="anchor" href="#15-executeoptions-%26-sqlresult" aria-hidden="true">#</a> 1.5 ExecuteOptions &amp; SqlResult</h3>
 <p>Both adapters expose <code>ExecuteOptions</code> and <code>SqlResult</code> for inspection and typing.</p>
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">ExecuteOptions</span> {
   <span class="hljs-attr">onSql</span>?: <span class="hljs-function">(<span class="hljs-params"><span class="hljs-attr">result</span>: <span class="hljs-title class_">SqlResult</span>&lt;<span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt;, <span class="hljs-built_in">unknown</span>&gt;</span>) =&gt;</span> <span class="hljs-built_in">void</span>;
@@ -373,7 +408,7 @@
 <h2 id="2-type-safe-contexts" tabindex="-1"><a class="anchor" href="#2-type-safe-contexts" aria-hidden="true">#</a> 2. Type-Safe Contexts</h2>
 <h3 id="21-createschema" tabindex="-1"><a class="anchor" href="#21-createschema" aria-hidden="true">#</a> 2.1 createSchema</h3>
 <p>Creates a phantom-typed <code>DatabaseSchema</code> that ties table names to row types. The schema is passed to execution functions, which provide a type-safe query builder through the lambda’s first parameter.</p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -383,17 +418,19 @@
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-comment">// Schema is passed to execute functions, which provide the query builder &#x27;q&#x27; parameter</span>
-<span class="hljs-keyword">const</span> results = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(db, schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-  q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">email</span>.<span class="hljs-title function_">endsWith</span>(<span class="hljs-string">&quot;@example.com&quot;</span>)),
+<span class="hljs-comment">// Schema is passed to defineSelect, which provides the query builder &#x27;q&#x27; parameter</span>
+<span class="hljs-keyword">const</span> results = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
+  db,
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">email</span>.<span class="hljs-title function_">endsWith</span>(<span class="hljs-string">&quot;@example.com&quot;</span>))),
+  {},
 );
 </code></pre>
 <hr>
 <h2 id="3-helper-utilities" tabindex="-1"><a class="anchor" href="#3-helper-utilities" aria-hidden="true">#</a> 3. Helper Utilities</h2>
 <h3 id="31-createqueryhelpers" tabindex="-1"><a class="anchor" href="#31-createqueryhelpers" aria-hidden="true">#</a> 3.1 createQueryHelpers</h3>
 <p>Provides helper functions for case-insensitive comparisons and string searches. Helpers are automatically passed as the third parameter to query builder functions.</p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, createQueryHelpers } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { selectStatement } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span> };
@@ -401,10 +438,10 @@
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-keyword">const</span> result = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> result = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> helpers.<span class="hljs-property">functions</span>.<span class="hljs-title function_">icontains</span>(u.<span class="hljs-property">name</span>, <span class="hljs-string">&quot;alice&quot;</span>)),
+  ),
   {},
 );
 </code></pre>
@@ -432,13 +469,11 @@
 <ul>
   <li><a href="#table-of-contents">Table of Contents</a></li>
   <li><a href="#1-execution-apis">1. Execution APIs</a></li>
-  <li class="toc-sub"><a href="#11-selectstatement">1.1 selectStatement</a></li>
-  <li class="toc-sub"><a href="#12-executeselect">1.2 executeSelect</a></li>
-  <li class="toc-sub"><a href="#13-insertstatement-%26-executeinsert">1.3 insertStatement & executeInsert</a></li>
-  <li class="toc-sub"><a href="#14-updatestatement-%26-executeupdate">1.4 updateStatement & executeUpdate</a></li>
-  <li class="toc-sub"><a href="#15-deletestatement-%26-executedelete">1.5 deleteStatement & executeDelete</a></li>
-  <li class="toc-sub"><a href="#16-statement-functions-(selectstatement%2C-insertstatement%2C-etc)">1.6 Statement Functions (selectStatement, insertStatement, etc.)</a></li>
-  <li class="toc-sub"><a href="#17-executeoptions-%26-sqlresult">1.7 ExecuteOptions & SqlResult</a></li>
+  <li class="toc-sub"><a href="#11-defineselect%2C-tosql-%26-executeselect">1.1 defineSelect, toSql & executeSelect</a></li>
+  <li class="toc-sub"><a href="#12-defineinsert%2C-tosql-%26-executeinsert">1.2 defineInsert, toSql & executeInsert</a></li>
+  <li class="toc-sub"><a href="#13-defineupdate%2C-tosql-%26-executeupdate">1.3 defineUpdate, toSql & executeUpdate</a></li>
+  <li class="toc-sub"><a href="#14-definedelete%2C-tosql-%26-executedelete">1.4 defineDelete, toSql & executeDelete</a></li>
+  <li class="toc-sub"><a href="#15-executeoptions-%26-sqlresult">1.5 ExecuteOptions & SqlResult</a></li>
   <li><a href="#2-type-safe-contexts">2. Type-Safe Contexts</a></li>
   <li class="toc-sub"><a href="#21-createschema">2.1 createSchema</a></li>
   <li><a href="#3-helper-utilities">3. Helper Utilities</a></li>

--- a/build/architecture.html
+++ b/build/architecture.html
@@ -63,7 +63,7 @@
 <li><code>@webpods/tinqer-sql-pg-promise</code> – PostgreSQL integration built on pg-promise</li>
 <li><code>@webpods/tinqer-sql-better-sqlite3</code> – SQLite integration powered by better-sqlite3</li>
 </ul>
-<p>Both adapters provide database context objects that expose a <code>dsl</code> property containing query builders (<code>from</code>, <code>query</code>, etc.). Applications receive the DSL through lambda parameters, allowing database switching without rewriting query code.</p>
+<p>Both adapters provide execution functions (<code>executeSelect</code>, <code>executeInsert</code>, etc.) that accept plan handles created by <code>define*</code> functions from the core package. Query plans are created using <code>defineSelect</code>, <code>defineInsert</code>, <code>defineUpdate</code>, and <code>defineDelete</code>, which parse query builder lambdas. Plans can then be executed with adapter-specific <code>execute*</code> functions or converted to SQL using <code>toSql</code>, allowing database switching without rewriting query code.</p>
 <h2 id="core-design-principles" tabindex="-1"><a class="anchor" href="#core-design-principles" aria-hidden="true">#</a> Core Design Principles</h2>
 <h3 id="dual-type-system" tabindex="-1"><a class="anchor" href="#dual-type-system" aria-hidden="true">#</a> Dual Type System</h3>
 <p>Tinqer employs a dual type system to provide both compile-time type safety and runtime SQL generation:</p>
@@ -560,16 +560,14 @@ normalizedOperation = <span class="hljs-title function_">normalizeXYZ</span>(nor
 </ul>
 <h2 id="api-layers" tabindex="-1"><a class="anchor" href="#api-layers" aria-hidden="true">#</a> API Layers</h2>
 <h3 id="user-facing-api-(compile-time)" tabindex="-1"><a class="anchor" href="#user-facing-api-(compile-time)" aria-hidden="true">#</a> User-Facing API (Compile-Time)</h3>
-<pre class="hljs"><code><span class="hljs-comment">// Database context provides DSL access</span>
+<pre class="hljs"><code><span class="hljs-comment">// Database schema provides type context</span>
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt; {
-  <span class="hljs-attr">dsl</span>: <span class="hljs-variable constant_">DSL</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;;
-  <span class="hljs-comment">// ... other context properties</span>
+  <span class="hljs-attr">_schemaType</span>?: <span class="hljs-title class_">TSchema</span>;
 }
 
-<span class="hljs-comment">// DSL object contains query builders</span>
-<span class="hljs-keyword">interface</span> DSL&lt;<span class="hljs-title class_">TSchema</span>&gt; {
+<span class="hljs-comment">// Query builder provides table access</span>
+<span class="hljs-keyword">interface</span> <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt; {
   <span class="hljs-keyword">from</span>&lt;<span class="hljs-title class_">TTable</span> <span class="hljs-keyword">extends</span> keyof <span class="hljs-title class_">TSchema</span>&gt;(<span class="hljs-attr">table</span>: <span class="hljs-title class_">TTable</span>): <span class="hljs-title class_">Queryable</span>&lt;<span class="hljs-title class_">TSchema</span>[<span class="hljs-title class_">TTable</span>]&gt;;
-  query&lt;<span class="hljs-title class_">TResult</span>&gt;(<span class="hljs-attr">builder</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TResult</span>&gt;): <span class="hljs-title class_">Queryable</span>&lt;<span class="hljs-title class_">TResult</span>&gt;;
 }
 
 <span class="hljs-comment">// Queryable class for type-safe chaining</span>
@@ -611,22 +609,41 @@ normalizedOperation = <span class="hljs-title function_">normalizeXYZ</span>(nor
 <span class="hljs-keyword">function</span> <span class="hljs-title function_">convertAstToQueryOperation</span>(<span class="hljs-params"><span class="hljs-attr">ast</span>: <span class="hljs-built_in">unknown</span></span>): <span class="hljs-title class_">QueryOperation</span>;
 </code></pre>
 <h3 id="sql-adapter-api" tabindex="-1"><a class="anchor" href="#sql-adapter-api" aria-hidden="true">#</a> SQL Adapter API</h3>
-<pre class="hljs"><code><span class="hljs-comment">// Main execution functions (in adapters)</span>
-<span class="hljs-keyword">function</span> selectStatement&lt;<span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TResult</span>&gt;(
+<pre class="hljs"><code><span class="hljs-comment">// Plan creation functions (in core package)</span>
+<span class="hljs-keyword">function</span> defineSelect&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TResult</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
   <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
-    <span class="hljs-attr">dsl</span>: DSL&lt;<span class="hljs-title class_">TSchema</span>&gt;,
+    <span class="hljs-attr">q</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
     <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
     <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">Helpers</span>,
   </span>) =&gt;</span> <span class="hljs-title class_">Queryable</span>&lt;<span class="hljs-title class_">TResult</span>&gt; | <span class="hljs-title class_">TerminalQuery</span>&lt;<span class="hljs-title class_">TResult</span>&gt;,
+  <span class="hljs-attr">paramDefaults</span>?: <span class="hljs-title class_">TParams</span>,
+): <span class="hljs-title class_">SelectPlanHandle</span>&lt;<span class="hljs-title class_">TResult</span>, <span class="hljs-title class_">TParams</span>&gt; | <span class="hljs-title class_">SelectTerminalHandle</span>&lt;<span class="hljs-title class_">TResult</span>, <span class="hljs-title class_">TParams</span>&gt;;
+
+<span class="hljs-keyword">function</span> defineInsert&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>&gt;(
+  <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
+  <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params"><span class="hljs-attr">q</span>: <span class="hljs-title class_">QueryBuilder</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;, <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>, <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">Helpers</span></span>) =&gt;</span> <span class="hljs-title class_">InsertQuery</span>,
+  <span class="hljs-attr">paramDefaults</span>?: <span class="hljs-title class_">TParams</span>,
+): <span class="hljs-title class_">InsertPlanHandle</span>&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>, <span class="hljs-title class_">TParams</span>&gt;;
+
+<span class="hljs-comment">// Execution functions (in adapters)</span>
+<span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeSelect&lt;<span class="hljs-title class_">TResult</span>, <span class="hljs-title class_">TParams</span>&gt;(
+  <span class="hljs-attr">db</span>: <span class="hljs-title class_">Database</span>,
+  <span class="hljs-attr">plan</span>: <span class="hljs-title class_">SelectPlanHandle</span>&lt;<span class="hljs-title class_">TResult</span>, <span class="hljs-title class_">TParams</span>&gt; | <span class="hljs-title class_">SelectTerminalHandle</span>&lt;<span class="hljs-title class_">TResult</span>, <span class="hljs-title class_">TParams</span>&gt;,
   <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
 ): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-title class_">TResult</span>[]&gt;;
 
-<span class="hljs-keyword">function</span> insertStatement&lt;<span class="hljs-title class_">TParams</span>&gt;(
-  <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
-  <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params"><span class="hljs-attr">dsl</span>: DSL&lt;<span class="hljs-title class_">TSchema</span>&gt;, <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>, <span class="hljs-attr">helpers</span>: <span class="hljs-title class_">Helpers</span></span>) =&gt;</span> <span class="hljs-title class_">InsertQuery</span>,
+<span class="hljs-keyword">async</span> <span class="hljs-keyword">function</span> executeInsert&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>, <span class="hljs-title class_">TParams</span>&gt;(
+  <span class="hljs-attr">db</span>: <span class="hljs-title class_">Database</span>,
+  <span class="hljs-attr">plan</span>: <span class="hljs-title class_">InsertPlanHandle</span>&lt;<span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span>, <span class="hljs-title class_">TParams</span>&gt;,
   <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
-): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-built_in">void</span>&gt;;
+): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-title class_">TReturning</span> <span class="hljs-keyword">extends</span> <span class="hljs-built_in">never</span> ? <span class="hljs-built_in">number</span> : <span class="hljs-title class_">TReturning</span>[]&gt;;
+
+<span class="hljs-comment">// SQL generation functions (in adapters, for testing/debugging)</span>
+<span class="hljs-keyword">function</span> toSql&lt;<span class="hljs-title class_">TParams</span>&gt;(
+  <span class="hljs-attr">plan</span>: <span class="hljs-title class_">SelectPlanHandle</span>&lt;<span class="hljs-built_in">unknown</span>, <span class="hljs-title class_">TParams</span>&gt; | <span class="hljs-title class_">SelectTerminalHandle</span>&lt;<span class="hljs-built_in">unknown</span>, <span class="hljs-title class_">TParams</span>&gt;,
+  <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span>,
+): { <span class="hljs-attr">sql</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">params</span>: <span class="hljs-title class_">TParams</span> &amp; <span class="hljs-title class_">Record</span>&lt;<span class="hljs-built_in">string</span>, <span class="hljs-built_in">unknown</span>&gt; };
 
 <span class="hljs-comment">// SQL generation (internal)</span>
 <span class="hljs-keyword">function</span> <span class="hljs-title function_">generateSql</span>(<span class="hljs-params"><span class="hljs-attr">operation</span>: <span class="hljs-title class_">QueryOperation</span>, <span class="hljs-attr">params</span>: <span class="hljs-built_in">unknown</span></span>): <span class="hljs-built_in">string</span>;
@@ -640,18 +657,21 @@ normalizedOperation = <span class="hljs-title function_">normalizeXYZ</span>(nor
 <pre class="hljs"><code><span class="hljs-comment">// Create database context</span>
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-comment">// Execute query with parameter pattern</span>
-<span class="hljs-keyword">const</span> result = <span class="hljs-keyword">await</span> <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, p</span>) =&gt;</span>
-    q
-      .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
-      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">x</span>) =&gt;</span> x.<span class="hljs-property">age</span> &gt;= p.<span class="hljs-property">minAge</span> &amp;&amp; x.<span class="hljs-property">department</span> === p.<span class="hljs-property">dept</span>)
-      .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">x</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: x.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: x.<span class="hljs-property">name</span>, <span class="hljs-attr">age</span>: x.<span class="hljs-property">age</span> }))
-      .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">x</span>) =&gt;</span> x.<span class="hljs-property">name</span>)
-      .<span class="hljs-title function_">take</span>(<span class="hljs-number">10</span>),
-  { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span>, <span class="hljs-attr">dept</span>: <span class="hljs-string">&quot;Engineering&quot;</span> },
+<span class="hljs-comment">// Define query plan</span>
+<span class="hljs-keyword">const</span> usersPlan = <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">p</span>: { minAge: <span class="hljs-built_in">number</span>; dept: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
+  q
+    .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
+    .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">x</span>) =&gt;</span> x.<span class="hljs-property">age</span> &gt;= p.<span class="hljs-property">minAge</span> &amp;&amp; x.<span class="hljs-property">department</span> === p.<span class="hljs-property">dept</span>)
+    .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">x</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: x.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: x.<span class="hljs-property">name</span>, <span class="hljs-attr">age</span>: x.<span class="hljs-property">age</span> }))
+    .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">x</span>) =&gt;</span> x.<span class="hljs-property">name</span>)
+    .<span class="hljs-title function_">take</span>(<span class="hljs-number">10</span>),
 );
+
+<span class="hljs-comment">// Execute query with parameters</span>
+<span class="hljs-keyword">const</span> result = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(db, usersPlan, {
+  <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span>,
+  <span class="hljs-attr">dept</span>: <span class="hljs-string">&quot;Engineering&quot;</span>,
+});
 </code></pre>
 <h3 id="parsed-expression-tree" tabindex="-1"><a class="anchor" href="#parsed-expression-tree" aria-hidden="true">#</a> Parsed Expression Tree</h3>
 <pre class="hljs"><code>{

--- a/build/development.html
+++ b/build/development.html
@@ -222,8 +222,8 @@ npm <span class="hljs-built_in">test</span>
 <p><strong>Unit Test Example:</strong></p>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> { describe, it } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;mocha&quot;</span>;
 <span class="hljs-keyword">import</span> { strict <span class="hljs-keyword">as</span> assert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;assert&quot;</span>;
-<span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { selectStatement } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-title function_">describe</span>(<span class="hljs-string">&quot;SQL Generation&quot;</span>, <span class="hljs-function">() =&gt;</span> {
   <span class="hljs-title function_">it</span>(<span class="hljs-string">&quot;should generate SQL with WHERE clause&quot;</span>, <span class="hljs-function">() =&gt;</span> {
@@ -232,7 +232,10 @@ npm <span class="hljs-built_in">test</span>
     }
 
     <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
-    <span class="hljs-keyword">const</span> result = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>));
+    <span class="hljs-keyword">const</span> result = <span class="hljs-title function_">toSql</span>(
+      <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>)),
+      {},
+    );
 
     <span class="hljs-comment">// Assert SQL and parameters</span>
     assert.<span class="hljs-title function_">ok</span>(result.<span class="hljs-property">sql</span>.<span class="hljs-title function_">includes</span>(<span class="hljs-string">&quot;WHERE&quot;</span>));
@@ -243,7 +246,7 @@ npm <span class="hljs-built_in">test</span>
 <p><strong>Integration Test Example:</strong></p>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> { describe, it, beforeEach } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;mocha&quot;</span>;
 <span class="hljs-keyword">import</span> { strict <span class="hljs-keyword">as</span> assert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;assert&quot;</span>;
-<span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 <span class="hljs-keyword">import</span> { db } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;./shared-db.js&quot;</span>;
 
@@ -258,12 +261,12 @@ npm <span class="hljs-built_in">test</span>
   <span class="hljs-title function_">it</span>(<span class="hljs-string">&quot;should execute SELECT query&quot;</span>, <span class="hljs-title function_">async</span> () =&gt; {
     <span class="hljs-keyword">const</span> results = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
       db,
-      schema,
-      <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+      <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
         q
           .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
           .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
           .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
+      ),
       { <span class="hljs-attr">minAge</span>: <span class="hljs-number">25</span> },
     );
 
@@ -469,13 +472,13 @@ pgp.<span class="hljs-title function_">end</span>(); <span class="hljs-comment">
 <pre class="hljs"><code><span class="hljs-comment">// Incorrect - template literal in lambda</span>
 .<span class="hljs-title function_">where</span>(<span class="hljs-function"><span class="hljs-params">u</span> =&gt;</span> u.<span class="hljs-property">name</span> === <span class="hljs-string">`User <span class="hljs-subst">${userId}</span>`</span>)
 
-<span class="hljs-comment">// Correct - use params with executeSelect</span>
+<span class="hljs-comment">// Correct - use params with defineSelect and executeSelect</span>
 <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { name: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span> === params.<span class="hljs-property">name</span>),
-  { <span class="hljs-attr">name</span>: <span class="hljs-string">`User <span class="hljs-subst">${userId}</span>`</span> }
+  ),
+  { <span class="hljs-attr">name</span>: <span class="hljs-string">`User <span class="hljs-subst">${userId}</span>`</span> },
 );
 </code></pre>
 <p><strong>Issue: Unknown Identifier</strong></p>
@@ -486,13 +489,13 @@ pgp.<span class="hljs-title function_">end</span>(); <span class="hljs-comment">
 <span class="hljs-keyword">const</span> minAge = <span class="hljs-number">18</span>;
 .<span class="hljs-title function_">where</span>(<span class="hljs-function"><span class="hljs-params">u</span> =&gt;</span> u.<span class="hljs-property">age</span> &gt;= minAge)
 
-<span class="hljs-comment">// Correct - params pattern with executeSelect</span>
+<span class="hljs-comment">// Correct - params pattern with defineSelect and executeSelect</span>
 <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>),
-  { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> }
+  ),
+  { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 </code></pre>
 <h3 id="63-type-errors" tabindex="-1"><a class="anchor" href="#63-type-errors" aria-hidden="true">#</a> 6.3 Type Errors</h3>
@@ -503,8 +506,8 @@ pgp.<span class="hljs-title function_">end</span>(); <span class="hljs-comment">
 <span class="hljs-comment">// Types will be &#x27;unknown&#x27; without schema</span>
 <span class="hljs-keyword">const</span> result = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>), <span class="hljs-comment">// Type is Queryable&lt;unknown&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)), <span class="hljs-comment">// Type is Queryable&lt;unknown&gt;</span>
+  {},
 );
 </code></pre>
 <p><strong>Solution:</strong> Provide explicit schema type to createSchema:</p>
@@ -517,8 +520,8 @@ pgp.<span class="hljs-title function_">end</span>(); <span class="hljs-comment">
 <span class="hljs-comment">// Now fully typed from schema</span>
 <span class="hljs-keyword">const</span> result = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>), <span class="hljs-comment">// Fully typed: Queryable&lt;{ id: number; name: string }&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)), <span class="hljs-comment">// Fully typed: Queryable&lt;{ id: number; name: string }&gt;</span>
+  {},
 );
 </code></pre>
 <p><strong>Issue: Property Does Not Exist</strong></p>

--- a/build/guide.html
+++ b/build/guide.html
@@ -148,7 +148,8 @@
 <h2 id="1-filtering-operations" tabindex="-1"><a class="anchor" href="#1-filtering-operations" aria-hidden="true">#</a> 1. Filtering Operations</h2>
 <p>The <code>where</code> method applies predicates to filter query results. Multiple <code>where</code> calls are combined with AND logic.</p>
 <h3 id="11-basic-comparison" tabindex="-1"><a class="anchor" href="#11-basic-comparison" aria-hidden="true">#</a> 1.1 Basic Comparison</h3>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">email</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">active</span>: <span class="hljs-built_in">boolean</span> };
@@ -156,7 +157,10 @@
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-keyword">const</span> adults = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>), {});
+<span class="hljs-keyword">const</span> adults = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>)),
+  {},
+);
 </code></pre>
 <pre class="hljs"><code><span class="hljs-comment">-- PostgreSQL</span>
 <span class="hljs-keyword">SELECT</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">WHERE</span> &quot;age&quot; <span class="hljs-operator">&gt;=</span> $(__p1)
@@ -167,14 +171,14 @@
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;__p1&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">18</span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <h3 id="12-multiple-predicates" tabindex="-1"><a class="anchor" href="#12-multiple-predicates" aria-hidden="true">#</a> 1.2 Multiple Predicates</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> activeRange = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> activeRange = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">21</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt;= <span class="hljs-number">60</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span> === <span class="hljs-literal">true</span>),
+  ),
   {},
 );
 </code></pre>
@@ -189,10 +193,10 @@
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;__p1&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">21</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;__p2&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">60</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;__p3&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <h3 id="13-logical-nesting-and-arithmetic" tabindex="-1"><a class="anchor" href="#13-logical-nesting-and-arithmetic" aria-hidden="true">#</a> 1.3 Logical Nesting and Arithmetic</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> premium = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> premium = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> (u.<span class="hljs-property">salary</span> * <span class="hljs-number">0.9</span> &gt; <span class="hljs-number">150_000</span> &amp;&amp; u.<span class="hljs-property">age</span> &lt; <span class="hljs-number">55</span>) || u.<span class="hljs-property">active</span> === <span class="hljs-literal">false</span>),
+  ),
   {},
 );
 </code></pre>
@@ -207,9 +211,8 @@
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;__p1&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">0.9</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;__p2&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">150000</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;__p3&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">55</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;__p4&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">false</span></span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <h3 id="14-null-checks-and-null-coalescing" tabindex="-1"><a class="anchor" href="#14-null-checks-and-null-coalescing" aria-hidden="true">#</a> 1.4 Null Checks and Null Coalescing</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> preferredName = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> (u.<span class="hljs-property">nickname</span> ?? u.<span class="hljs-property">name</span>) === <span class="hljs-string">&quot;anonymous&quot;</span>),
+<pre class="hljs"><code><span class="hljs-keyword">const</span> preferredName = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> (u.<span class="hljs-property">nickname</span> ?? u.<span class="hljs-property">name</span>) === <span class="hljs-string">&quot;anonymous&quot;</span>)),
   {},
 );
 </code></pre>
@@ -222,14 +225,14 @@
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;__p1&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;anonymous&quot;</span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <h3 id="15-string-operations" tabindex="-1"><a class="anchor" href="#15-string-operations" aria-hidden="true">#</a> 1.5 String Operations</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> emailFilters = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> emailFilters = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">email</span>.<span class="hljs-title function_">startsWith</span>(<span class="hljs-string">&quot;admin&quot;</span>))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">email</span>.<span class="hljs-title function_">endsWith</span>(<span class="hljs-string">&quot;@example.com&quot;</span>))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>.<span class="hljs-title function_">toLowerCase</span>() === <span class="hljs-string">&quot;john&quot;</span>),
+  ),
   {},
 );
 </code></pre>
@@ -248,9 +251,10 @@
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;__p1&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;admin&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;__p2&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;@example.com&quot;</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;__p3&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;john&quot;</span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <h3 id="16-case-insensitive-helpers" tabindex="-1"><a class="anchor" href="#16-case-insensitive-helpers" aria-hidden="true">#</a> 1.6 Case-Insensitive Helpers</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> insensitive = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> helpers.<span class="hljs-property">functions</span>.<span class="hljs-title function_">iequals</span>(u.<span class="hljs-property">name</span>, <span class="hljs-string">&quot;ALICE&quot;</span>)),
+<pre class="hljs"><code><span class="hljs-keyword">const</span> insensitive = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> helpers.<span class="hljs-property">functions</span>.<span class="hljs-title function_">iequals</span>(u.<span class="hljs-property">name</span>, <span class="hljs-string">&quot;ALICE&quot;</span>)),
+  ),
   {},
 );
 </code></pre>
@@ -263,9 +267,10 @@
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;__p1&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;ALICE&quot;</span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <h3 id="17-array-membership-(in)" tabindex="-1"><a class="anchor" href="#17-array-membership-(in)" aria-hidden="true">#</a> 1.7 Array Membership (IN)</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> allowed = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> [<span class="hljs-string">&quot;admin&quot;</span>, <span class="hljs-string">&quot;support&quot;</span>, <span class="hljs-string">&quot;auditor&quot;</span>].<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">role</span>)),
+<pre class="hljs"><code><span class="hljs-keyword">const</span> allowed = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> [<span class="hljs-string">&quot;admin&quot;</span>, <span class="hljs-string">&quot;support&quot;</span>, <span class="hljs-string">&quot;auditor&quot;</span>].<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">role</span>)),
+  ),
   {},
 );
 </code></pre>
@@ -279,14 +284,14 @@
 </code></pre>
 <p>Negating the predicate (<code>!array.includes(...)</code>) yields <code>NOT IN</code>.</p>
 <h3 id="18-combined-filter-example" tabindex="-1"><a class="anchor" href="#18-combined-filter-example" aria-hidden="true">#</a> 1.8 Combined Filter Example</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> advancedFilter = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> advancedFilter = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span>; categories: <span class="hljs-built_in">string</span>[] }, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> params.<span class="hljs-property">categories</span>.<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">departmentId</span>.<span class="hljs-title function_">toString</span>()))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> helpers.<span class="hljs-property">functions</span>.<span class="hljs-title function_">icontains</span>(u.<span class="hljs-property">email</span>, <span class="hljs-string">&quot;company&quot;</span>)),
+  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">25</span>, <span class="hljs-attr">categories</span>: [<span class="hljs-string">&quot;10&quot;</span>, <span class="hljs-string">&quot;11&quot;</span>] },
 );
 </code></pre>
@@ -314,7 +319,10 @@
 <h2 id="2-projections" tabindex="-1"><a class="anchor" href="#2-projections" aria-hidden="true">#</a> 2. Projections</h2>
 <p>The <code>select</code> method transforms query results by projecting columns or computed expressions.</p>
 <h3 id="21-full-row-projection" tabindex="-1"><a class="anchor" href="#21-full-row-projection" aria-hidden="true">#</a> 2.1 Full Row Projection</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> fullRow = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>), {});
+<pre class="hljs"><code><span class="hljs-keyword">const</span> fullRow = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)),
+  {},
+);
 </code></pre>
 <pre class="hljs"><code><span class="hljs-comment">-- PostgreSQL</span>
 <span class="hljs-keyword">SELECT</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">FROM</span> &quot;users&quot;
@@ -323,9 +331,8 @@
 <span class="hljs-keyword">SELECT</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">FROM</span> &quot;users&quot;
 </code></pre>
 <h3 id="22-object-projection" tabindex="-1"><a class="anchor" href="#22-object-projection" aria-hidden="true">#</a> 2.2 Object Projection</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> summary = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> summary = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span>)
@@ -336,6 +343,7 @@
           <span class="hljs-attr">email</span>: u.<span class="hljs-property">email</span>,
         },
       })),
+  ),
   {},
 );
 </code></pre>
@@ -351,14 +359,14 @@
 }
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">ProductSchema</span>&gt;();
 
-<span class="hljs-keyword">const</span> pricing = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> pricing = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;products&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> ({
       <span class="hljs-attr">id</span>: p.<span class="hljs-property">id</span>,
       <span class="hljs-attr">name</span>: p.<span class="hljs-property">name</span>,
       <span class="hljs-attr">effectivePrice</span>: p.<span class="hljs-property">price</span> - (p.<span class="hljs-property">discount</span> ?? <span class="hljs-number">0</span>),
     })),
+  ),
   {},
 );
 </code></pre>
@@ -374,7 +382,10 @@
 <h2 id="3-ordering" tabindex="-1"><a class="anchor" href="#3-ordering" aria-hidden="true">#</a> 3. Ordering</h2>
 <p>Methods <code>orderBy</code>, <code>orderByDescending</code>, <code>thenBy</code>, and <code>thenByDescending</code> control result ordering.</p>
 <h3 id="31-single-key-ascending" tabindex="-1"><a class="anchor" href="#31-single-key-ascending" aria-hidden="true">#</a> 3.1 Single Key Ascending</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> alphabetical = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>), {});
+<pre class="hljs"><code><span class="hljs-keyword">const</span> alphabetical = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>)),
+  {},
+);
 </code></pre>
 <pre class="hljs"><code><span class="hljs-comment">-- PostgreSQL</span>
 <span class="hljs-keyword">SELECT</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">ORDER</span> <span class="hljs-keyword">BY</span> &quot;name&quot; <span class="hljs-keyword">ASC</span>
@@ -383,14 +394,14 @@
 <span class="hljs-keyword">SELECT</span> <span class="hljs-operator">*</span> <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">ORDER</span> <span class="hljs-keyword">BY</span> &quot;name&quot; <span class="hljs-keyword">ASC</span>
 </code></pre>
 <h3 id="32-mixed-ordering" tabindex="-1"><a class="anchor" href="#32-mixed-ordering" aria-hidden="true">#</a> 3.2 Mixed Ordering</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> ordered = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> ordered = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>)
       .<span class="hljs-title function_">thenByDescending</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">salary</span>)
       .<span class="hljs-title function_">thenBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
+  ),
   {},
 );
 </code></pre>
@@ -402,13 +413,13 @@
 </code></pre>
 <hr>
 <h2 id="4-distinct-operations" tabindex="-1"><a class="anchor" href="#4-distinct-operations" aria-hidden="true">#</a> 4. Distinct Operations</h2>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> departments = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> departments = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>)
       .<span class="hljs-title function_">distinct</span>(),
+  ),
   {},
 );
 </code></pre>
@@ -422,14 +433,14 @@
 <h2 id="5-pagination" tabindex="-1"><a class="anchor" href="#5-pagination" aria-hidden="true">#</a> 5. Pagination</h2>
 <p>Methods <code>skip</code> and <code>take</code> implement OFFSET and LIMIT clauses.</p>
 <h3 id="51-offset%2Flimit-pattern" tabindex="-1"><a class="anchor" href="#51-offset%2Flimit-pattern" aria-hidden="true">#</a> 5.1 Offset/Limit Pattern</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> page = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> page = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span>)
       .<span class="hljs-title function_">skip</span>(<span class="hljs-number">30</span>)
       .<span class="hljs-title function_">take</span>(<span class="hljs-number">15</span>),
+  ),
   {},
 );
 </code></pre>
@@ -442,15 +453,15 @@
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;__p1&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">30</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;__p2&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">15</span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <h3 id="52-pagination-with-filtering" tabindex="-1"><a class="anchor" href="#52-pagination-with-filtering" aria-hidden="true">#</a> 5.2 Pagination with Filtering</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> filteredPage = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> filteredPage = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>)
       .<span class="hljs-title function_">skip</span>(<span class="hljs-number">50</span>)
       .<span class="hljs-title function_">take</span>(<span class="hljs-number">25</span>),
+  ),
   {},
 );
 </code></pre>
@@ -472,15 +483,15 @@
 }
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">JoinSchema</span>&gt;();
 
-<span class="hljs-keyword">const</span> userDepartments = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> userDepartments = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">join</span>(
       q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;departments&quot;</span>),
       <span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>,
       <span class="hljs-function">(<span class="hljs-params">d</span>) =&gt;</span> d.<span class="hljs-property">id</span>,
       <span class="hljs-function">(<span class="hljs-params">u, d</span>) =&gt;</span> ({ <span class="hljs-attr">userName</span>: u.<span class="hljs-property">name</span>, <span class="hljs-attr">departmentName</span>: d.<span class="hljs-property">name</span> }),
     ),
+  ),
   {},
 );
 </code></pre>
@@ -501,9 +512,8 @@
 }
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">OrderSchema</span>&gt;();
 
-<span class="hljs-keyword">const</span> regionOrders = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> regionOrders = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> &gt; <span class="hljs-number">100</span>)
@@ -514,6 +524,7 @@
         <span class="hljs-function">(<span class="hljs-params">u, o</span>) =&gt;</span> ({ <span class="hljs-attr">userName</span>: u.<span class="hljs-property">name</span>, <span class="hljs-attr">total</span>: o.<span class="hljs-property">total</span> }),
       )
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">row</span>) =&gt;</span> row.<span class="hljs-property">total</span> &gt; <span class="hljs-number">500</span>),
+  ),
   {},
 );
 </code></pre>
@@ -532,9 +543,8 @@
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;__p1&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">100</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;__p2&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">500</span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <h3 id="63-join-with-grouped-results" tabindex="-1"><a class="anchor" href="#63-join-with-grouped-results" aria-hidden="true">#</a> 6.3 Join with Grouped Results</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> totalsByDepartment = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> totalsByDepartment = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">join</span>(
@@ -549,6 +559,7 @@
         <span class="hljs-attr">totalOrders</span>: g.<span class="hljs-title function_">count</span>(),
         <span class="hljs-attr">revenue</span>: g.<span class="hljs-title function_">sum</span>(<span class="hljs-function">(<span class="hljs-params">row</span>) =&gt;</span> row.<span class="hljs-property">o</span>.<span class="hljs-property">total</span>),
       })),
+  ),
   {},
 );
 </code></pre>
@@ -566,9 +577,8 @@
 </code></pre>
 <h3 id="64-left-outer-join" tabindex="-1"><a class="anchor" href="#64-left-outer-join" aria-hidden="true">#</a> 6.4 Left Outer Join</h3>
 <p>Model the classic LINQ pattern: start with <code>groupJoin</code>, then expand the grouped results with <code>selectMany(...defaultIfEmpty())</code>. Any missing matches appear as <code>null</code> in the projection.</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> usersWithDepartments = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> usersWithDepartments = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">groupJoin</span>(
@@ -585,6 +595,7 @@
         <span class="hljs-attr">userId</span>: row.<span class="hljs-property">user</span>.<span class="hljs-property">id</span>,
         <span class="hljs-attr">departmentName</span>: row.<span class="hljs-property">department</span> ? row.<span class="hljs-property">department</span>.<span class="hljs-property">name</span> : <span class="hljs-literal">null</span>,
       })),
+  ),
   {},
 );
 </code></pre>
@@ -600,9 +611,8 @@
 </code></pre>
 <h3 id="65-cross-join" tabindex="-1"><a class="anchor" href="#65-cross-join" aria-hidden="true">#</a> 6.5 Cross Join</h3>
 <p>Return a <code>Queryable</code> from the collection selector passed to <code>selectMany</code>. Because we skip <code>defaultIfEmpty</code>, the parser normalizes the operation into a <code>CROSS JOIN</code>.</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> departmentUsers = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> departmentUsers = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;departments&quot;</span>)
       .<span class="hljs-title function_">selectMany</span>(
@@ -613,6 +623,7 @@
         <span class="hljs-attr">departmentId</span>: row.<span class="hljs-property">department</span>.<span class="hljs-property">id</span>,
         <span class="hljs-attr">userId</span>: row.<span class="hljs-property">user</span>.<span class="hljs-property">id</span>,
       })),
+  ),
   {},
 );
 </code></pre>
@@ -631,9 +642,8 @@
 <h2 id="7-grouping-and-aggregation" tabindex="-1"><a class="anchor" href="#7-grouping-and-aggregation" aria-hidden="true">#</a> 7. Grouping and Aggregation</h2>
 <p>The <code>groupBy</code> method groups results and enables aggregate functions: <code>count</code>, <code>sum</code>, <code>avg</code>, <code>min</code>, <code>max</code>.</p>
 <h3 id="71-basic-grouping" tabindex="-1"><a class="anchor" href="#71-basic-grouping" aria-hidden="true">#</a> 7.1 Basic Grouping</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> byDepartment = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">groupBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>),
+<pre class="hljs"><code><span class="hljs-keyword">const</span> byDepartment = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">groupBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>)),
   {},
 );
 </code></pre>
@@ -644,9 +654,8 @@
 <span class="hljs-keyword">SELECT</span> &quot;departmentId&quot; <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">GROUP</span> <span class="hljs-keyword">BY</span> &quot;departmentId&quot;
 </code></pre>
 <h3 id="72-group-with-multiple-aggregates" tabindex="-1"><a class="anchor" href="#72-group-with-multiple-aggregates" aria-hidden="true">#</a> 7.2 Group with Multiple Aggregates</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> departmentStats = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> departmentStats = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">groupBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>)
@@ -658,6 +667,7 @@
         <span class="hljs-attr">maxSalary</span>: g.<span class="hljs-title function_">max</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">salary</span>),
       }))
       .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">row</span>) =&gt;</span> row.<span class="hljs-property">totalSalary</span>),
+  ),
   {},
 );
 </code></pre>
@@ -676,13 +686,13 @@
 <h3 id="73-group-with-post-filter" tabindex="-1"><a class="anchor" href="#73-group-with-post-filter" aria-hidden="true">#</a> 7.3 Group with Post-Filter</h3>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> largeDepartments = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">groupBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">g</span>) =&gt;</span> ({ <span class="hljs-attr">departmentId</span>: g.<span class="hljs-property">key</span>, <span class="hljs-attr">headcount</span>: g.<span class="hljs-title function_">count</span>() }))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">row</span>) =&gt;</span> row.<span class="hljs-property">headcount</span> &gt; <span class="hljs-number">5</span>),
+  ),
   {},
 );
 </code></pre>
@@ -703,9 +713,8 @@
 }
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">EmployeeSchema</span>&gt;();
 
-<span class="hljs-keyword">const</span> rankedEmployees = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> rankedEmployees = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
       <span class="hljs-attr">department</span>: e.<span class="hljs-property">department</span>,
@@ -716,6 +725,7 @@
         .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">salary</span>)
         .<span class="hljs-title function_">rowNumber</span>(),
     })),
+  ),
   {},
 );
 </code></pre>
@@ -735,9 +745,8 @@
 }
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">OrderTimeSchema</span>&gt;();
 
-<span class="hljs-keyword">const</span> chronological = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> chronological = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;orders&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">o</span>) =&gt;</span> ({
       <span class="hljs-attr">orderId</span>: o.<span class="hljs-property">id</span>,
       <span class="hljs-attr">rowNum</span>: helpers
@@ -745,6 +754,7 @@
         .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">createdAt</span>)
         .<span class="hljs-title function_">rowNumber</span>(),
     })),
+  ),
   {},
 );
 </code></pre>
@@ -758,9 +768,8 @@
 }
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">RegionEmployeeSchema</span>&gt;();
 
-<span class="hljs-keyword">const</span> multiPartition = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> multiPartition = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
       <span class="hljs-attr">rank</span>: helpers
@@ -772,6 +781,7 @@
         .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">salary</span>)
         .<span class="hljs-title function_">rowNumber</span>(),
     })),
+  ),
   {},
 );
 </code></pre>
@@ -781,9 +791,8 @@
 <span class="hljs-keyword">FROM</span> &quot;employees&quot;
 </code></pre>
 <h4 id="secondary-ordering-with-thenby" tabindex="-1"><a class="anchor" href="#secondary-ordering-with-thenby" aria-hidden="true">#</a> Secondary Ordering with thenBy</h4>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> ranked = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> ranked = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
       <span class="hljs-attr">rank</span>: helpers
@@ -793,6 +802,7 @@
         .<span class="hljs-title function_">thenBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">name</span>)
         .<span class="hljs-title function_">rowNumber</span>(),
     })),
+  ),
   {},
 );
 </code></pre>
@@ -803,9 +813,8 @@
 </code></pre>
 <h3 id="82-rank" tabindex="-1"><a class="anchor" href="#82-rank" aria-hidden="true">#</a> 8.2 RANK</h3>
 <p><code>RANK()</code> assigns ranks with gaps for tied values. If two rows have the same rank, the next rank skips numbers.</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> rankedSalaries = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> rankedSalaries = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
       <span class="hljs-attr">salary</span>: e.<span class="hljs-property">salary</span>,
@@ -815,6 +824,7 @@
         .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">salary</span>)
         .<span class="hljs-title function_">rank</span>(),
     })),
+  ),
   {},
 );
 </code></pre>
@@ -862,9 +872,8 @@
 }
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">PlayerSchema</span>&gt;();
 
-<span class="hljs-keyword">const</span> globalRank = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> globalRank = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;players&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> ({
       <span class="hljs-attr">player</span>: p.<span class="hljs-property">name</span>,
       <span class="hljs-attr">score</span>: p.<span class="hljs-property">score</span>,
@@ -873,6 +882,7 @@
         .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">score</span>)
         .<span class="hljs-title function_">rank</span>(),
     })),
+  ),
   {},
 );
 </code></pre>
@@ -882,9 +892,8 @@
 </code></pre>
 <h3 id="83-dense_rank" tabindex="-1"><a class="anchor" href="#83-dense_rank" aria-hidden="true">#</a> 8.3 DENSE_RANK</h3>
 <p><code>DENSE_RANK()</code> assigns ranks without gaps. Tied values receive the same rank, and the next rank is consecutive.</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> denseRanked = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> denseRanked = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
       <span class="hljs-attr">salary</span>: e.<span class="hljs-property">salary</span>,
@@ -894,6 +903,7 @@
         .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">salary</span>)
         .<span class="hljs-title function_">denseRank</span>(),
     })),
+  ),
   {},
 );
 </code></pre>
@@ -940,9 +950,8 @@
 }
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">EmployeeAgeSchema</span>&gt;();
 
-<span class="hljs-keyword">const</span> complexRanking = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> complexRanking = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
       <span class="hljs-attr">rank</span>: helpers
@@ -953,6 +962,7 @@
         .<span class="hljs-title function_">thenBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">name</span>)
         .<span class="hljs-title function_">denseRank</span>(),
     })),
+  ),
   {},
 );
 </code></pre>
@@ -966,9 +976,8 @@
 </code></pre>
 <h3 id="84-multiple-window-functions" tabindex="-1"><a class="anchor" href="#84-multiple-window-functions" aria-hidden="true">#</a> 8.4 Multiple Window Functions</h3>
 <p>Combine multiple window functions in a single SELECT:</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> allRankings = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> allRankings = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>).<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
       <span class="hljs-attr">name</span>: e.<span class="hljs-property">name</span>,
       <span class="hljs-attr">department</span>: e.<span class="hljs-property">department</span>,
@@ -989,6 +998,7 @@
         .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">salary</span>)
         .<span class="hljs-title function_">denseRank</span>(),
     })),
+  ),
   {},
 );
 </code></pre>
@@ -1012,8 +1022,7 @@
 <p>Get the top earner from each department:</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> topEarners = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
@@ -1026,6 +1035,7 @@
       }))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">rank</span> === <span class="hljs-number">1</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">department</span>),
+  ),
   {},
 );
 </code></pre>
@@ -1054,8 +1064,7 @@
 
 <span class="hljs-keyword">const</span> top3Engineering = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { deptId: <span class="hljs-built_in">number</span> }, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
@@ -1069,6 +1078,7 @@
       }))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">rank</span> &lt;= <span class="hljs-number">3</span> &amp;&amp; r.<span class="hljs-property">department_id</span> === params.<span class="hljs-property">deptId</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">rank</span>),
+  ),
   { <span class="hljs-attr">deptId</span>: <span class="hljs-number">1</span> },
 );
 </code></pre>
@@ -1090,8 +1100,7 @@
 
 <span class="hljs-keyword">const</span> topPerformers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
@@ -1102,6 +1111,7 @@
           .<span class="hljs-title function_">rowNumber</span>(),
       }))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">performance_rank</span> &lt;= <span class="hljs-number">10</span>),
+  ),
   {},
 );
 </code></pre>
@@ -1121,8 +1131,7 @@
 
 <span class="hljs-keyword">const</span> activeTopEarners = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
@@ -1139,6 +1148,7 @@
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">dept_rank</span> &lt;= <span class="hljs-number">2</span> &amp;&amp; r.<span class="hljs-property">is_active</span> === <span class="hljs-literal">true</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">department</span>)
       .<span class="hljs-title function_">thenBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">dept_rank</span>),
+  ),
   {},
 );
 </code></pre>
@@ -1156,13 +1166,13 @@
 <hr>
 <h2 id="9-scalar-aggregates-on-root-queries" tabindex="-1"><a class="anchor" href="#9-scalar-aggregates-on-root-queries" aria-hidden="true">#</a> 9. Scalar Aggregates on Root Queries</h2>
 <p>Aggregate methods can be called directly on queries to return single values.</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> totals = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> totals = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span> === <span class="hljs-literal">true</span>)
       .<span class="hljs-title function_">sum</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">salary</span>),
+  ),
   {},
 );
 </code></pre>
@@ -1175,7 +1185,10 @@
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;__p1&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-literal"><span class="hljs-keyword">true</span></span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <p>Methods <code>count</code>, <code>average</code>, <code>min</code>, and <code>max</code> follow the same structure. The <code>count</code> method also accepts a predicate:</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> activeCount = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">count</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span>), {});
+<pre class="hljs"><code><span class="hljs-keyword">const</span> activeCount = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">count</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span>)),
+  {},
+);
 </code></pre>
 <pre class="hljs"><code><span class="hljs-comment">-- PostgreSQL</span>
 <span class="hljs-keyword">SELECT</span> <span class="hljs-built_in">COUNT</span>(<span class="hljs-operator">*</span>) <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">WHERE</span> &quot;active&quot;
@@ -1187,7 +1200,10 @@
 <h2 id="10-quantifiers" tabindex="-1"><a class="anchor" href="#10-quantifiers" aria-hidden="true">#</a> 10. Quantifiers</h2>
 <p>Methods <code>any</code> and <code>all</code> test whether elements satisfy conditions.</p>
 <h3 id="101-any-operation" tabindex="-1"><a class="anchor" href="#101-any-operation" aria-hidden="true">#</a> 10.1 Any Operation</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> hasAdults = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">any</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>), {});
+<pre class="hljs"><code><span class="hljs-keyword">const</span> hasAdults = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">any</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>)),
+  {},
+);
 </code></pre>
 <pre class="hljs"><code><span class="hljs-comment">-- PostgreSQL</span>
 <span class="hljs-keyword">SELECT</span> <span class="hljs-keyword">CASE</span> <span class="hljs-keyword">WHEN</span> <span class="hljs-keyword">EXISTS</span>(<span class="hljs-keyword">SELECT</span> <span class="hljs-number">1</span> <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">WHERE</span> &quot;age&quot; <span class="hljs-operator">&gt;=</span> $(__p1)) <span class="hljs-keyword">THEN</span> <span class="hljs-number">1</span> <span class="hljs-keyword">ELSE</span> <span class="hljs-number">0</span> <span class="hljs-keyword">END</span>
@@ -1199,9 +1215,8 @@
 </code></pre>
 <h3 id="102-all-operation" tabindex="-1"><a class="anchor" href="#102-all-operation" aria-hidden="true">#</a> 10.2 All Operation</h3>
 <p>The <code>all</code> method emits a <code>NOT EXISTS</code> check:</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> allActive = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">all</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span> === <span class="hljs-literal">true</span>),
+<pre class="hljs"><code><span class="hljs-keyword">const</span> allActive = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">all</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span> === <span class="hljs-literal">true</span>)),
   {},
 );
 </code></pre>
@@ -1214,13 +1229,13 @@
 <hr>
 <h2 id="11-element-retrieval" tabindex="-1"><a class="anchor" href="#11-element-retrieval" aria-hidden="true">#</a> 11. Element Retrieval</h2>
 <p>Methods <code>first</code>, <code>firstOrDefault</code>, <code>single</code>, <code>singleOrDefault</code>, <code>last</code>, and <code>lastOrDefault</code> retrieve single elements.</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> newestUser = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> newestUser = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">createdAt</span>)
       .<span class="hljs-title function_">last</span>(),
+  ),
   {},
 );
 </code></pre>
@@ -1240,12 +1255,12 @@
 <p>Queries are executed directly without requiring a materialization method. The query builder returns results as arrays by default.</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> activeUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
+  ),
   {},
 );
 </code></pre>
@@ -1254,13 +1269,13 @@
 <h2 id="13-parameters-and-auto-parameterisation" tabindex="-1"><a class="anchor" href="#13-parameters-and-auto-parameterisation" aria-hidden="true">#</a> 13. Parameters and Auto-Parameterisation</h2>
 <p>Tinqer automatically parameterizes all values to prevent SQL injection and enable prepared statements.</p>
 <h3 id="131-external-parameter-objects" tabindex="-1"><a class="anchor" href="#131-external-parameter-objects" aria-hidden="true">#</a> 13.1 External Parameter Objects</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> filtered = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> filtered = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span>; role: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">role</span> === params.<span class="hljs-property">role</span>),
+  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">30</span>, <span class="hljs-attr">role</span>: <span class="hljs-string">&quot;manager&quot;</span> },
 );
 </code></pre>
@@ -1274,9 +1289,10 @@
 </code></pre>
 <p>Nested properties and array indices are preserved (<code>params.filters.departments[0]</code>).</p>
 <h3 id="132-literal-auto-parameterisation" tabindex="-1"><a class="anchor" href="#132-literal-auto-parameterisation" aria-hidden="true">#</a> 13.2 Literal Auto-Parameterisation</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> autoParams = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span> === <span class="hljs-number">7</span> &amp;&amp; u.<span class="hljs-property">name</span>.<span class="hljs-title function_">startsWith</span>(<span class="hljs-string">&quot;A&quot;</span>)),
+<pre class="hljs"><code><span class="hljs-keyword">const</span> autoParams = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span> === <span class="hljs-number">7</span> &amp;&amp; u.<span class="hljs-property">name</span>.<span class="hljs-title function_">startsWith</span>(<span class="hljs-string">&quot;A&quot;</span>)),
+  ),
   {},
 );
 </code></pre>
@@ -1289,9 +1305,8 @@
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;__p1&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">7</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;__p2&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-string">&quot;A&quot;</span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <h3 id="133-array-membership" tabindex="-1"><a class="anchor" href="#133-array-membership" aria-hidden="true">#</a> 13.3 Array Membership</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> membership = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>].<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">id</span>)),
+<pre class="hljs"><code><span class="hljs-keyword">const</span> membership = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>].<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">id</span>))),
   {},
 );
 </code></pre>
@@ -1304,19 +1319,20 @@
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;__p1&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">1</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;__p2&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">2</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;__p3&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">3</span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <p>Parameterized array example:</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> dynamicMembership = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> params.<span class="hljs-property">allowed</span>.<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">id</span>)),
+<pre class="hljs"><code><span class="hljs-keyword">const</span> dynamicMembership = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { allowed: <span class="hljs-built_in">number</span>[] }</span>) =&gt;</span>
+    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> params.<span class="hljs-property">allowed</span>.<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">id</span>)),
+  ),
   { <span class="hljs-attr">allowed</span>: [<span class="hljs-number">5</span>, <span class="hljs-number">8</span>] },
 );
 </code></pre>
 <pre class="hljs"><code><span class="hljs-punctuation">{</span> <span class="hljs-attr">&quot;allowed[0]&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">5</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">&quot;allowed[1]&quot;</span><span class="hljs-punctuation">:</span> <span class="hljs-number">8</span> <span class="hljs-punctuation">}</span>
 </code></pre>
 <h3 id="134-case-insensitive-helper-functions" tabindex="-1"><a class="anchor" href="#134-case-insensitive-helper-functions" aria-hidden="true">#</a> 13.4 Case-Insensitive Helper Functions</h3>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> ic = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> ic = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> helpers.<span class="hljs-property">functions</span>.<span class="hljs-title function_">icontains</span>(u.<span class="hljs-property">email</span>, <span class="hljs-string">&quot;support&quot;</span>)),
+  ),
   {},
 );
 </code></pre>
@@ -1334,8 +1350,8 @@
 <h3 id="141-insert-statements" tabindex="-1"><a class="anchor" href="#141-insert-statements" aria-hidden="true">#</a> 14.1 INSERT Statements</h3>
 <p>The <code>insertInto</code> function creates INSERT operations. Values are specified using direct object syntax (no lambda wrapping required).</p>
 <h4 id="basic-insert" tabindex="-1"><a class="anchor" href="#basic-insert" aria-hidden="true">#</a> Basic INSERT</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, insertInto } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { insertStatement } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">email</span>: <span class="hljs-built_in">string</span> };
@@ -1343,14 +1359,14 @@
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
 <span class="hljs-comment">// Insert with literal values - direct object syntax</span>
-<span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">insertStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
       <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Alice&quot;</span>,
       <span class="hljs-attr">age</span>: <span class="hljs-number">30</span>,
       <span class="hljs-attr">email</span>: <span class="hljs-string">&quot;alice@example.com&quot;</span>,
     }),
+  ),
   {},
 );
 </code></pre>
@@ -1365,14 +1381,14 @@
 </code></pre>
 <h4 id="insert-with-external-parameters" tabindex="-1"><a class="anchor" href="#insert-with-external-parameters" aria-hidden="true">#</a> INSERT with External Parameters</h4>
 <p>External variables must be passed via the params object - closure variables are not supported:</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">insertStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { name: <span class="hljs-built_in">string</span>; age: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
       <span class="hljs-attr">name</span>: params.<span class="hljs-property">name</span>,
       <span class="hljs-attr">age</span>: params.<span class="hljs-property">age</span>,
       <span class="hljs-attr">email</span>: <span class="hljs-string">&quot;default@example.com&quot;</span>,
     }),
+  ),
   { <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Bob&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">25</span> },
 );
 </code></pre>
@@ -1387,54 +1403,56 @@
 <h4 id="insert-with-returning-clause" tabindex="-1"><a class="anchor" href="#insert-with-returning-clause" aria-hidden="true">#</a> INSERT with RETURNING Clause</h4>
 <p>Both PostgreSQL and SQLite (3.35.0+) support the RETURNING clause to retrieve values from inserted rows:</p>
 <pre class="hljs"><code><span class="hljs-comment">// Return specific columns</span>
-<span class="hljs-keyword">const</span> insertWithReturn = <span class="hljs-title function_">insertStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> insertWithReturn = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Charlie&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">35</span> })
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">createdAt</span>: u.<span class="hljs-property">createdAt</span> })),
+  ),
   {},
 );
 
 <span class="hljs-comment">// Return all columns</span>
-<span class="hljs-keyword">const</span> insertReturnAll = <span class="hljs-title function_">insertStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    q
-      .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
-      .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;David&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">40</span> })
-      .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u), <span class="hljs-comment">// Returns *</span>
+<span class="hljs-keyword">const</span> insertReturnAll = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineInsert</span>(
+    schema,
+    <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+      q
+        .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
+        .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;David&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">40</span> })
+        .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u), <span class="hljs-comment">// Returns *</span>
+  ),
   {},
 );
 </code></pre>
 <h4 id="null-values-in-insert" tabindex="-1"><a class="anchor" href="#null-values-in-insert" aria-hidden="true">#</a> NULL Values in INSERT</h4>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">insertStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
       <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Eve&quot;</span>,
       <span class="hljs-attr">email</span>: <span class="hljs-literal">null</span>, <span class="hljs-comment">// Generates NULL, not parameterized</span>
       <span class="hljs-attr">phone</span>: <span class="hljs-literal">undefined</span>, <span class="hljs-comment">// Column omitted from INSERT</span>
     }),
+  ),
   {},
 );
 </code></pre>
 <h3 id="142-update-statements" tabindex="-1"><a class="anchor" href="#142-update-statements" aria-hidden="true">#</a> 14.2 UPDATE Statements</h3>
 <p>The <code>update</code> function creates UPDATE operations. The <code>.set()</code> method uses direct object syntax (no lambda wrapping required).</p>
 <h4 id="basic-update" tabindex="-1"><a class="anchor" href="#basic-update" aria-hidden="true">#</a> Basic UPDATE</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, update } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { updateStatement } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineUpdate } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-keyword">const</span> updateStmt = <span class="hljs-title function_">updateStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> updateStmt = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: <span class="hljs-number">31</span>, <span class="hljs-attr">lastModified</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>() })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">1</span>),
+  ),
   {},
 );
 </code></pre>
@@ -1454,44 +1472,46 @@
 </blockquote>
 <h4 id="update-with-external-parameters" tabindex="-1"><a class="anchor" href="#update-with-external-parameters" aria-hidden="true">#</a> UPDATE with External Parameters</h4>
 <p>External variables must be passed via the params object:</p>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> updateStmt = <span class="hljs-title function_">updateStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> updateStmt = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { newAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: params.<span class="hljs-property">newAge</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">1</span>),
+  ),
   { <span class="hljs-attr">newAge</span>: <span class="hljs-number">32</span> },
 );
 </code></pre>
 <h4 id="update-with-complex-where" tabindex="-1"><a class="anchor" href="#update-with-complex-where" aria-hidden="true">#</a> UPDATE with Complex WHERE</h4>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> updateStmt = <span class="hljs-title function_">updateStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> updateStmt = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">lastLogin</span> &lt; <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>(<span class="hljs-string">&quot;2023-01-01&quot;</span>) &amp;&amp; u.<span class="hljs-property">role</span> !== <span class="hljs-string">&quot;admin&quot;</span>),
+  ),
   {},
 );
 </code></pre>
 <h4 id="update-with-returning-clause" tabindex="-1"><a class="anchor" href="#update-with-returning-clause" aria-hidden="true">#</a> UPDATE with RETURNING Clause</h4>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> updateWithReturn = <span class="hljs-title function_">updateStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> updateWithReturn = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: <span class="hljs-number">32</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">2</span>)
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">age</span>: u.<span class="hljs-property">age</span>, <span class="hljs-attr">updatedAt</span>: u.<span class="hljs-property">updatedAt</span> })),
+  ),
   {},
 );
 </code></pre>
 <h4 id="full-table-update-(requires-explicit-permission)" tabindex="-1"><a class="anchor" href="#full-table-update-(requires-explicit-permission)" aria-hidden="true">#</a> Full Table UPDATE (Requires Explicit Permission)</h4>
 <pre class="hljs"><code><span class="hljs-comment">// UPDATE without WHERE requires explicit permission</span>
-<span class="hljs-keyword">const</span> updateAll = <span class="hljs-title function_">updateStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">set</span>({ <span class="hljs-attr">isActive</span>: <span class="hljs-literal">true</span> }).<span class="hljs-title function_">allowFullTableUpdate</span>(), <span class="hljs-comment">// Required flag</span>
+<span class="hljs-keyword">const</span> updateAll = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineUpdate</span>(
+    schema,
+    <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">set</span>({ <span class="hljs-attr">isActive</span>: <span class="hljs-literal">true</span> }).<span class="hljs-title function_">allowFullTableUpdate</span>(), <span class="hljs-comment">// Required flag</span>
+  ),
   {},
 );
 </code></pre>
@@ -1502,31 +1522,35 @@ Full table updates are dangerous and must be explicitly allowed.
 <h3 id="143-delete-statements" tabindex="-1"><a class="anchor" href="#143-delete-statements" aria-hidden="true">#</a> 14.3 DELETE Statements</h3>
 <p>The <code>deleteFrom</code> function creates DELETE operations with optional WHERE conditions.</p>
 <h4 id="basic-delete" tabindex="-1"><a class="anchor" href="#basic-delete" aria-hidden="true">#</a> Basic DELETE</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, deleteFrom } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { deleteStatement } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-keyword">const</span> del = <span class="hljs-title function_">deleteStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">100</span>), {});
+<span class="hljs-keyword">const</span> del = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">100</span>)),
+  {},
+);
 </code></pre>
 <p>Generated SQL:</p>
 <pre class="hljs"><code><span class="hljs-keyword">DELETE</span> <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">WHERE</span> &quot;age&quot; <span class="hljs-operator">&gt;</span> $(__p1)  <span class="hljs-comment">-- PostgreSQL</span>
 <span class="hljs-keyword">DELETE</span> <span class="hljs-keyword">FROM</span> &quot;users&quot; <span class="hljs-keyword">WHERE</span> &quot;age&quot; <span class="hljs-operator">&gt;</span> @__p1    <span class="hljs-comment">-- SQLite</span>
 </code></pre>
 <h4 id="delete-with-complex-conditions" tabindex="-1"><a class="anchor" href="#delete-with-complex-conditions" aria-hidden="true">#</a> DELETE with Complex Conditions</h4>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> del = <span class="hljs-title function_">deleteStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> del = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">isDeleted</span> === <span class="hljs-literal">true</span> || (u.<span class="hljs-property">age</span> &lt; <span class="hljs-number">18</span> &amp;&amp; u.<span class="hljs-property">role</span> !== <span class="hljs-string">&quot;admin&quot;</span>) || u.<span class="hljs-property">email</span> === <span class="hljs-literal">null</span>),
+  ),
   {},
 );
 </code></pre>
 <h4 id="delete-with-in-clause" tabindex="-1"><a class="anchor" href="#delete-with-in-clause" aria-hidden="true">#</a> DELETE with IN Clause</h4>
-<pre class="hljs"><code><span class="hljs-keyword">const</span> del = <span class="hljs-title function_">deleteStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> params.<span class="hljs-property">userIds</span>.<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">id</span>)),
+<pre class="hljs"><code><span class="hljs-keyword">const</span> del = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { userIds: <span class="hljs-built_in">number</span>[] }</span>) =&gt;</span>
+    q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> params.<span class="hljs-property">userIds</span>.<span class="hljs-title function_">includes</span>(u.<span class="hljs-property">id</span>)),
+  ),
   { <span class="hljs-attr">userIds</span>: [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>, <span class="hljs-number">4</span>, <span class="hljs-number">5</span>] },
 );
 </code></pre>
@@ -1550,9 +1574,8 @@ Full table updates are dangerous and must be explicitly allowed.
 </code></pre>
 <h4 id="full-table-delete-(requires-explicit-permission)" tabindex="-1"><a class="anchor" href="#full-table-delete-(requires-explicit-permission)" aria-hidden="true">#</a> Full Table DELETE (Requires Explicit Permission)</h4>
 <pre class="hljs"><code><span class="hljs-comment">// DELETE without WHERE requires explicit permission</span>
-<span class="hljs-keyword">const</span> deleteAll = <span class="hljs-title function_">deleteStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">allowFullTableDelete</span>(), <span class="hljs-comment">// Required flag</span>
+<span class="hljs-keyword">const</span> deleteAll = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">allowFullTableDelete</span>()), <span class="hljs-comment">// Required flag</span>
   {},
 );
 </code></pre>
@@ -1561,11 +1584,17 @@ Full table updates are dangerous and must be explicitly allowed.
 <h4 id="mandatory-where-clauses" tabindex="-1"><a class="anchor" href="#mandatory-where-clauses" aria-hidden="true">#</a> Mandatory WHERE Clauses</h4>
 <p>UPDATE and DELETE operations require WHERE clauses by default to prevent accidental full-table operations:</p>
 <pre class="hljs"><code><span class="hljs-comment">// This throws an error</span>
-<span class="hljs-title function_">deleteStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>), {});
+<span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>)),
+  {},
+);
 <span class="hljs-comment">// Error: DELETE requires a WHERE clause or explicit allowFullTableDelete()</span>
 
 <span class="hljs-comment">// This works</span>
-<span class="hljs-title function_">deleteStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">allowFullTableDelete</span>(), {});
+<span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">allowFullTableDelete</span>()),
+  {},
+);
 </code></pre>
 <h4 id="type-safety" tabindex="-1"><a class="anchor" href="#type-safety" aria-hidden="true">#</a> Type Safety</h4>
 <p>All CRUD operations maintain full TypeScript type safety:</p>
@@ -1575,34 +1604,34 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">UserSchema</span>&gt;();
 
 <span class="hljs-comment">// Type error: &#x27;username&#x27; doesn&#x27;t exist on users table</span>
-<span class="hljs-title function_">insertStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
       <span class="hljs-attr">username</span>: <span class="hljs-string">&quot;Alice&quot;</span>, <span class="hljs-comment">// ❌ Type error</span>
     }),
+  ),
   {},
 );
 
 <span class="hljs-comment">// Type error: age must be number</span>
-<span class="hljs-title function_">updateStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q.<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">set</span>({
       <span class="hljs-attr">age</span>: <span class="hljs-string">&quot;30&quot;</span>, <span class="hljs-comment">// ❌ Type error - must be number</span>
     }),
+  ),
   {},
 );
 </code></pre>
 <h4 id="parameter-sanitization" tabindex="-1"><a class="anchor" href="#parameter-sanitization" aria-hidden="true">#</a> Parameter Sanitization</h4>
 <p>All values are automatically parameterized to prevent SQL injection:</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> maliciousName = <span class="hljs-string">&quot;&#x27;; DROP TABLE users; --&quot;</span>;
-<span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">insertStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
       <span class="hljs-attr">name</span>: maliciousName, <span class="hljs-comment">// Safely parameterized</span>
     }),
+  ),
   {},
 );
 <span class="hljs-comment">// Generates: INSERT INTO &quot;users&quot; (&quot;name&quot;) VALUES ($(__p1))</span>
@@ -1611,17 +1640,20 @@ Full table updates are dangerous and must be explicitly allowed.
 <h3 id="145-executing-crud-operations" tabindex="-1"><a class="anchor" href="#145-executing-crud-operations" aria-hidden="true">#</a> 14.5 Executing CRUD Operations</h3>
 <p>The adapter packages provide execution functions for all CRUD operations:</p>
 <h4 id="postgresql-(pg-promise)" tabindex="-1"><a class="anchor" href="#postgresql-(pg-promise)" aria-hidden="true">#</a> PostgreSQL (pg-promise)</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert, defineUpdate, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
 <span class="hljs-comment">// Execute INSERT with RETURNING</span>
 <span class="hljs-keyword">const</span> insertedUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Frank&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">28</span> })
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
+  ),
   {},
 );
 <span class="hljs-comment">// Returns: [{ id: 123, name: &quot;Frank&quot; }]</span>
@@ -1629,12 +1661,12 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-comment">// Execute UPDATE - returns affected row count</span>
 <span class="hljs-keyword">const</span> updateCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeUpdate</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: <span class="hljs-number">29</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">123</span>),
+  ),
   {},
 );
 <span class="hljs-comment">// Returns number of affected rows</span>
@@ -1642,19 +1674,20 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-comment">// Execute DELETE - returns affected row count</span>
 <span class="hljs-keyword">const</span> deleteCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeDelete</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">123</span>),
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">123</span>)),
   {},
 );
 </code></pre>
 <h4 id="sqlite-(better-sqlite3)" tabindex="-1"><a class="anchor" href="#sqlite-(better-sqlite3)" aria-hidden="true">#</a> SQLite (better-sqlite3)</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-better-sqlite3&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert, defineUpdate, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-better-sqlite3&quot;</span>;
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
 <span class="hljs-comment">// Execute INSERT - returns row count</span>
 <span class="hljs-keyword">const</span> insertCount = <span class="hljs-title function_">executeInsert</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Grace&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">30</span> }),
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Grace&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">30</span> })),
   {},
 );
 <span class="hljs-comment">// Returns number of inserted rows</span>
@@ -1662,24 +1695,23 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-comment">// Execute UPDATE - returns row count</span>
 <span class="hljs-keyword">const</span> updateCount = <span class="hljs-title function_">executeUpdate</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: <span class="hljs-number">33</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span> === <span class="hljs-string">&quot;Henry&quot;</span>),
+  ),
   {},
 );
 
 <span class="hljs-comment">// Execute DELETE - returns row count</span>
 <span class="hljs-keyword">const</span> deleteCount = <span class="hljs-title function_">executeDelete</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">100</span>),
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">100</span>)),
   {},
 );
 </code></pre>
-<p>SQLite helpers always return the number of affected rows. To inspect row data after an insert or update, run a follow-up <code>selectStatement</code> query.</p>
+<p>SQLite helpers always return the number of affected rows. To inspect row data after an insert or update, run a follow-up SELECT query using <code>defineSelect</code> and <code>executeSelect</code>.</p>
 <h4 id="transaction-support" tabindex="-1"><a class="anchor" href="#transaction-support" aria-hidden="true">#</a> Transaction Support</h4>
 <p>Both adapters support transactions through their respective database drivers:</p>
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">TxSchema</span> {
@@ -1692,38 +1724,42 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-keyword">await</span> db.<span class="hljs-title function_">tx</span>(<span class="hljs-title function_">async</span> (t) =&gt; {
   <span class="hljs-keyword">const</span> users = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
     t,
-    schema,
-    <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+    <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
       q
         .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
         .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Ivy&quot;</span> })
         .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span>),
+    ),
     {},
   );
 
   <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
     t,
-    schema,
-    <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+    <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
       q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;user_logs&quot;</span>).<span class="hljs-title function_">values</span>({
         <span class="hljs-attr">userId</span>: users[<span class="hljs-number">0</span>]!.<span class="hljs-property">id</span>,
         <span class="hljs-attr">action</span>: <span class="hljs-string">&quot;created&quot;</span>,
       }),
+    ),
     {},
   );
 });
 
 <span class="hljs-comment">// SQLite transactions</span>
 <span class="hljs-keyword">const</span> transaction = sqliteDb.<span class="hljs-title function_">transaction</span>(<span class="hljs-function">() =&gt;</span> {
-  <span class="hljs-title function_">executeInsert</span>(db, schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Jack&quot;</span> }), {});
+  <span class="hljs-title function_">executeInsert</span>(
+    db,
+    <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Jack&quot;</span> })),
+    {},
+  );
   <span class="hljs-title function_">executeUpdate</span>(
     db,
-    schema,
-    <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+    <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
       q
         .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
         .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">lastLogin</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>() })
         .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span> === <span class="hljs-string">&quot;Jack&quot;</span>),
+    ),
     {},
   );
 });

--- a/build/index.html
+++ b/build/index.html
@@ -70,7 +70,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
 </code></pre>
 <h2 id="quick-start" tabindex="-1"><a class="anchor" href="#quick-start" aria-hidden="true">#</a> Quick Start</h2>
 <h3 id="postgresql-example" tabindex="-1"><a class="anchor" href="#postgresql-example" aria-hidden="true">#</a> PostgreSQL Example</h3>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 <span class="hljs-keyword">import</span> pgPromise <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;pg-promise&quot;</span>;
 
@@ -89,20 +89,20 @@ npm install @webpods/tinqer-sql-better-sqlite3
 
 <span class="hljs-keyword">const</span> results = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
+  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 <span class="hljs-comment">// results: [{ id: 1, name: &quot;Alice&quot; }, { id: 2, name: &quot;Bob&quot; }]</span>
 </code></pre>
 <p><strong>The same query works with SQLite</strong> - just change the adapter and database connection:</p>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> <span class="hljs-title class_">Database</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;better-sqlite3&quot;</span>;
-<span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-better-sqlite3&quot;</span>;
 
 <span class="hljs-comment">// Same schema definition</span>
@@ -121,26 +121,27 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <span class="hljs-comment">// Identical query logic</span>
 <span class="hljs-keyword">const</span> results = <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
+  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 <span class="hljs-comment">// results: [{ id: 1, name: &quot;Alice&quot; }, { id: 2, name: &quot;Bob&quot; }]</span>
 </code></pre>
 <h3 id="sql-generation-without-execution" tabindex="-1"><a class="anchor" href="#sql-generation-without-execution" aria-hidden="true">#</a> SQL Generation Without Execution</h3>
-<p><strong><code>execute*</code> functions</strong> execute queries and return results. <strong><code>*Statement</code> functions</strong> generate SQL and parameters without executing - useful for debugging, logging, or custom execution:</p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> {
-  selectStatement,
-  insertStatement,
-  updateStatement,
-  deleteStatement,
-} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<p><strong><code>execute*</code> functions</strong> execute queries and return results. <strong><code>toSql</code> function</strong> generates SQL and parameters without executing - useful for debugging, logging, or custom execution:</p>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> {
+  createSchema,
+  defineSelect,
+  defineInsert,
+  defineUpdate,
+  defineDelete,
+} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span> };
@@ -149,38 +150,41 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
 <span class="hljs-comment">// SELECT - returns { sql, params }</span>
-<span class="hljs-keyword">const</span> select = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>),
+<span class="hljs-keyword">const</span> select = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>),
+  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 <span class="hljs-comment">// select.sql: SELECT * FROM &quot;users&quot; WHERE &quot;age&quot; &gt;= $(minAge)</span>
 <span class="hljs-comment">// select.params: { minAge: 18 }</span>
 
 <span class="hljs-comment">// INSERT</span>
-<span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">insertStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: params.<span class="hljs-property">name</span>, <span class="hljs-attr">age</span>: params.<span class="hljs-property">age</span> }),
+<span class="hljs-keyword">const</span> insert = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { name: <span class="hljs-built_in">string</span>; age: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+    q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: params.<span class="hljs-property">name</span>, <span class="hljs-attr">age</span>: params.<span class="hljs-property">age</span> }),
+  ),
   { <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Alice&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">30</span> },
 );
 <span class="hljs-comment">// insert.sql: INSERT INTO &quot;users&quot; (&quot;name&quot;, &quot;age&quot;) VALUES ($(name), $(age))</span>
 
 <span class="hljs-comment">// UPDATE</span>
-<span class="hljs-keyword">const</span> update = <span class="hljs-title function_">updateStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+<span class="hljs-keyword">const</span> update = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { newAge: <span class="hljs-built_in">number</span>; userId: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: params.<span class="hljs-property">newAge</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === params.<span class="hljs-property">userId</span>),
+  ),
   { <span class="hljs-attr">newAge</span>: <span class="hljs-number">31</span>, <span class="hljs-attr">userId</span>: <span class="hljs-number">1</span> },
 );
 <span class="hljs-comment">// update.sql: UPDATE &quot;users&quot; SET &quot;age&quot; = $(newAge) WHERE &quot;id&quot; = $(userId)</span>
 
 <span class="hljs-comment">// DELETE</span>
-<span class="hljs-keyword">const</span> del = <span class="hljs-title function_">deleteStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt; params.<span class="hljs-property">minAge</span>),
+<span class="hljs-keyword">const</span> del = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+    q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt; params.<span class="hljs-property">minAge</span>),
+  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 <span class="hljs-comment">// del.sql: DELETE FROM &quot;users&quot; WHERE &quot;age&quot; &lt; $(minAge)</span>
@@ -278,19 +282,21 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <pre class="hljs"><code><span class="hljs-comment">// Get top earner per department (automatically wrapped in subquery)</span>
 <span class="hljs-keyword">const</span> topEarners = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params, h</span>) =&gt;</span>
-    q
-      .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
-      .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
-        ...e,
-        <span class="hljs-attr">rank</span>: h
-          .<span class="hljs-title function_">window</span>(e)
-          .<span class="hljs-title function_">partitionBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">department</span>)
-          .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">salary</span>)
-          .<span class="hljs-title function_">rowNumber</span>(),
-      }))
-      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> e.<span class="hljs-property">rank</span> === <span class="hljs-number">1</span>), <span class="hljs-comment">// Filtering on window function result</span>
+  <span class="hljs-title function_">defineSelect</span>(
+    schema,
+    <span class="hljs-function">(<span class="hljs-params">q, params, h</span>) =&gt;</span>
+      q
+        .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
+        .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
+          ...e,
+          <span class="hljs-attr">rank</span>: h
+            .<span class="hljs-title function_">window</span>(e)
+            .<span class="hljs-title function_">partitionBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">department</span>)
+            .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">salary</span>)
+            .<span class="hljs-title function_">rowNumber</span>(),
+        }))
+        .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> e.<span class="hljs-property">rank</span> === <span class="hljs-number">1</span>), <span class="hljs-comment">// Filtering on window function result</span>
+  ),
   {},
 );
 
@@ -304,7 +310,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <p><strong>Automatic Subquery Wrapping</strong>: Tinqer automatically detects when <code>where()</code> clauses reference window function columns and wraps the query in a subquery, since SQL doesn’t allow filtering on window functions at the same level where they’re defined.</p>
 <p>See the <a href="docs/guide.md#8-window-functions">Window Functions Guide</a> for detailed examples of <code>RANK()</code>, <code>DENSE_RANK()</code>, complex ordering, and <a href="docs/guide.md#85-filtering-on-window-function-results">filtering on window results</a>.</p>
 <h3 id="crud-operations" tabindex="-1"><a class="anchor" href="#crud-operations" aria-hidden="true">#</a> CRUD Operations</h3>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert, defineUpdate, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
@@ -312,25 +318,25 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <span class="hljs-comment">// INSERT</span>
 <span class="hljs-keyword">const</span> insertedRows = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
       <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Alice&quot;</span>,
       <span class="hljs-attr">email</span>: <span class="hljs-string">&quot;alice@example.com&quot;</span>,
     }),
+  ),
   {},
 );
 
 <span class="hljs-comment">// UPDATE with RETURNING</span>
 <span class="hljs-keyword">const</span> inactiveUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeUpdate</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span>
+  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoffDate: <span class="hljs-built_in">Date</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">lastLogin</span> &lt; params.<span class="hljs-property">cutoffDate</span>)
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span>),
+  ),
   { <span class="hljs-attr">cutoffDate</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>(<span class="hljs-string">&quot;2023-01-01&quot;</span>) },
 );
 
@@ -339,8 +345,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <span class="hljs-comment">// DELETE</span>
 <span class="hljs-keyword">const</span> deletedCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeDelete</span>(
   db,
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">status</span> === <span class="hljs-string">&quot;deleted&quot;</span>),
+  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">status</span> === <span class="hljs-string">&quot;deleted&quot;</span>)),
   {},
 );
 
@@ -351,16 +356,20 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <pre class="hljs"><code><span class="hljs-comment">// External parameters via params object</span>
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-keyword">const</span> sample = <span class="hljs-title function_">selectStatement</span>(
-  schema,
-  <span class="hljs-function">(<span class="hljs-params">q, params</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>),
+<span class="hljs-keyword">const</span> sample = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+    q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>),
+  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 <span class="hljs-comment">// SQL (PostgreSQL): SELECT * FROM &quot;users&quot; WHERE &quot;age&quot; &gt;= $(minAge)</span>
 <span class="hljs-comment">// params: { minAge: 18 }</span>
 
 <span class="hljs-comment">// Literals auto-parameterized automatically</span>
-<span class="hljs-keyword">const</span> literals = <span class="hljs-title function_">selectStatement</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>), {});
+<span class="hljs-keyword">const</span> literals = <span class="hljs-title function_">toSql</span>(
+  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">18</span>)),
+  {},
+);
 <span class="hljs-comment">// params: { __p1: 18 }</span>
 </code></pre>
 <h3 id="case-insensitive-string-operations" tabindex="-1"><a class="anchor" href="#case-insensitive-string-operations" aria-hidden="true">#</a> Case-Insensitive String Operations</h3>
@@ -415,7 +424,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <h2 id="differences-from-net-linq-to-sql" tabindex="-1"><a class="anchor" href="#differences-from-net-linq-to-sql" aria-hidden="true">#</a> Differences from .NET LINQ to SQL</h2>
 <ul>
 <li>Lambdas cannot capture external variables; use params object</li>
-<li>Limited method set (no <code>SelectMany</code>, <code>GroupJoin</code>, <code>DefaultIfEmpty</code>)</li>
+<li>Join operations (<code>join</code>, <code>groupJoin</code>, <code>selectMany</code>) must be composed inside the defineSelect builder; they cannot be chained on plan handles</li>
 <li>Left outer joins and cross joins supported via LINQ patterns (right/full joins still require manual SQL)</li>
 <li>No deferred execution; SQL generated on demand</li>
 <li>Grouping supports <code>count</code>, <code>sum</code>, <code>avg</code>, <code>min</code>, <code>max</code></li>

--- a/build/llms.txt
+++ b/build/llms.txt
@@ -30,7 +30,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
 ### PostgreSQL Example
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
+import { createSchema, defineSelect } from "@webpods/tinqer";
 import { executeSelect } from "@webpods/tinqer-sql-pg-promise";
 import pgPromise from "pg-promise";
 
@@ -49,13 +49,13 @@ const schema = createSchema<Schema>();
 
 const results = await executeSelect(
   db,
-  schema,
-  (q, params) =>
+  defineSelect(schema, (q, params: { minAge: number }) =>
     q
       .from("users")
       .where((u) => u.age >= params.minAge)
       .orderBy((u) => u.name)
       .select((u) => ({ id: u.id, name: u.name })),
+  ),
   { minAge: 18 },
 );
 // results: [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }]
@@ -65,7 +65,7 @@ const results = await executeSelect(
 
 ```typescript
 import Database from "better-sqlite3";
-import { createSchema } from "@webpods/tinqer";
+import { createSchema, defineSelect } from "@webpods/tinqer";
 import { executeSelect } from "@webpods/tinqer-sql-better-sqlite3";
 
 // Same schema definition
@@ -84,13 +84,13 @@ const schema = createSchema<Schema>();
 // Identical query logic
 const results = executeSelect(
   db,
-  schema,
-  (q, params) =>
+  defineSelect(schema, (q, params: { minAge: number }) =>
     q
       .from("users")
       .where((u) => u.age >= params.minAge)
       .orderBy((u) => u.name)
       .select((u) => ({ id: u.id, name: u.name })),
+  ),
   { minAge: 18 },
 );
 // results: [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }]
@@ -98,16 +98,17 @@ const results = executeSelect(
 
 ### SQL Generation Without Execution
 
-**`execute*` functions** execute queries and return results. **`*Statement` functions** generate SQL and parameters without executing - useful for debugging, logging, or custom execution:
+**`execute*` functions** execute queries and return results. **`toSql` function** generates SQL and parameters without executing - useful for debugging, logging, or custom execution:
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
 import {
-  selectStatement,
-  insertStatement,
-  updateStatement,
-  deleteStatement,
-} from "@webpods/tinqer-sql-pg-promise";
+  createSchema,
+  defineSelect,
+  defineInsert,
+  defineUpdate,
+  defineDelete,
+} from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
   users: { id: number; name: string; age: number };
@@ -116,38 +117,41 @@ interface Schema {
 const schema = createSchema<Schema>();
 
 // SELECT - returns { sql, params }
-const select = selectStatement(
-  schema,
-  (q, params) => q.from("users").where((u) => u.age >= params.minAge),
+const select = toSql(
+  defineSelect(schema, (q, params: { minAge: number }) =>
+    q.from("users").where((u) => u.age >= params.minAge),
+  ),
   { minAge: 18 },
 );
 // select.sql: SELECT * FROM "users" WHERE "age" >= $(minAge)
 // select.params: { minAge: 18 }
 
 // INSERT
-const insert = insertStatement(
-  schema,
-  (q, params) => q.insertInto("users").values({ name: params.name, age: params.age }),
+const insert = toSql(
+  defineInsert(schema, (q, params: { name: string; age: number }) =>
+    q.insertInto("users").values({ name: params.name, age: params.age }),
+  ),
   { name: "Alice", age: 30 },
 );
 // insert.sql: INSERT INTO "users" ("name", "age") VALUES ($(name), $(age))
 
 // UPDATE
-const update = updateStatement(
-  schema,
-  (q, params) =>
+const update = toSql(
+  defineUpdate(schema, (q, params: { newAge: number; userId: number }) =>
     q
       .update("users")
       .set({ age: params.newAge })
       .where((u) => u.id === params.userId),
+  ),
   { newAge: 31, userId: 1 },
 );
 // update.sql: UPDATE "users" SET "age" = $(newAge) WHERE "id" = $(userId)
 
 // DELETE
-const del = deleteStatement(
-  schema,
-  (q, params) => q.deleteFrom("users").where((u) => u.age < params.minAge),
+const del = toSql(
+  defineDelete(schema, (q, params: { minAge: number }) =>
+    q.deleteFrom("users").where((u) => u.age < params.minAge),
+  ),
   { minAge: 18 },
 );
 // del.sql: DELETE FROM "users" WHERE "age" < $(minAge)
@@ -268,19 +272,21 @@ Window functions enable calculations across rows related to the current row. Tin
 // Get top earner per department (automatically wrapped in subquery)
 const topEarners = await executeSelect(
   db,
-  schema,
-  (q, params, h) =>
-    q
-      .from("employees")
-      .select((e) => ({
-        ...e,
-        rank: h
-          .window(e)
-          .partitionBy((r) => r.department)
-          .orderByDescending((r) => r.salary)
-          .rowNumber(),
-      }))
-      .where((e) => e.rank === 1), // Filtering on window function result
+  defineSelect(
+    schema,
+    (q, params, h) =>
+      q
+        .from("employees")
+        .select((e) => ({
+          ...e,
+          rank: h
+            .window(e)
+            .partitionBy((r) => r.department)
+            .orderByDescending((r) => r.salary)
+            .rowNumber(),
+        }))
+        .where((e) => e.rank === 1), // Filtering on window function result
+  ),
   {},
 );
 
@@ -299,7 +305,7 @@ See the [Window Functions Guide](docs/guide.md#8-window-functions) for detailed 
 ### CRUD Operations
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
+import { createSchema, defineInsert, defineUpdate, defineDelete } from "@webpods/tinqer";
 import { executeInsert, executeUpdate, executeDelete } from "@webpods/tinqer-sql-pg-promise";
 
 const schema = createSchema<Schema>();
@@ -307,25 +313,25 @@ const schema = createSchema<Schema>();
 // INSERT
 const insertedRows = await executeInsert(
   db,
-  schema,
-  (q) =>
+  defineInsert(schema, (q) =>
     q.insertInto("users").values({
       name: "Alice",
       email: "alice@example.com",
     }),
+  ),
   {},
 );
 
 // UPDATE with RETURNING
 const inactiveUsers = await executeUpdate(
   db,
-  schema,
-  (q, params) =>
+  defineUpdate(schema, (q, params: { cutoffDate: Date }) =>
     q
       .update("users")
       .set({ status: "inactive" })
       .where((u) => u.lastLogin < params.cutoffDate)
       .returning((u) => u.id),
+  ),
   { cutoffDate: new Date("2023-01-01") },
 );
 
@@ -334,8 +340,7 @@ const inactiveUsers = await executeUpdate(
 // DELETE
 const deletedCount = await executeDelete(
   db,
-  schema,
-  (q) => q.deleteFrom("users").where((u) => u.status === "deleted"),
+  defineDelete(schema, (q) => q.deleteFrom("users").where((u) => u.status === "deleted")),
   {},
 );
 
@@ -350,16 +355,20 @@ All literal values are automatically parameterized to prevent SQL injection:
 // External parameters via params object
 const schema = createSchema<Schema>();
 
-const sample = selectStatement(
-  schema,
-  (q, params) => q.from("users").where((u) => u.age >= params.minAge),
+const sample = toSql(
+  defineSelect(schema, (q, params: { minAge: number }) =>
+    q.from("users").where((u) => u.age >= params.minAge),
+  ),
   { minAge: 18 },
 );
 // SQL (PostgreSQL): SELECT * FROM "users" WHERE "age" >= $(minAge)
 // params: { minAge: 18 }
 
 // Literals auto-parameterized automatically
-const literals = selectStatement(schema, (q) => q.from("users").where((u) => u.age >= 18), {});
+const literals = toSql(
+  defineSelect(schema, (q) => q.from("users").where((u) => u.age >= 18)),
+  {},
+);
 // params: { __p1: 18 }
 ```
 
@@ -422,7 +431,7 @@ See [Database Adapters](docs/adapters.md) for detailed comparison.
 ## Differences from .NET LINQ to SQL
 
 - Lambdas cannot capture external variables; use params object
-- Limited method set (no `SelectMany`, `GroupJoin`, `DefaultIfEmpty`)
+- Join operations (`join`, `groupJoin`, `selectMany`) must be composed inside the defineSelect builder; they cannot be chained on plan handles
 - Left outer joins and cross joins supported via LINQ patterns (right/full joins still require manual SQL)
 - No deferred execution; SQL generated on demand
 - Grouping supports `count`, `sum`, `avg`, `min`, `max`
@@ -493,13 +502,19 @@ npm install @webpods/tinqer-sql-pg-promise pg-promise
 
 ```typescript
 import pgPromise from "pg-promise";
-import { createSchema } from "@webpods/tinqer";
+import {
+  createSchema,
+  defineSelect,
+  defineInsert,
+  defineUpdate,
+  defineDelete,
+} from "@webpods/tinqer";
 import {
   executeSelect,
   executeInsert,
   executeUpdate,
   executeDelete,
-  selectStatement,
+  toSql,
 } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
@@ -513,63 +528,61 @@ const schema = createSchema<Schema>();
 // Execute with params
 const activeUsers = await executeSelect(
   db,
-  schema,
-  (q, params) =>
+  defineSelect(schema, (q, params: { minAge: number }) =>
     q
       .from("users")
       .where((u) => u.active && u.age >= params.minAge)
       .orderBy((u) => u.name),
+  ),
   { minAge: 18 },
 );
 
 // Execute with params
 const matchingUsers = await executeSelect(
   db,
-  schema,
-  (q, params) =>
+  defineSelect(schema, (q, params: { minAge: number }) =>
     q
       .from("users")
       .where((u) => u.age >= params.minAge)
       .select((u) => ({ id: u.id, name: u.name })),
+  ),
   { minAge: 21 },
 );
 
 // INSERT with RETURNING
 const createdUsers = await executeInsert(
   db,
-  schema,
-  (q) =>
+  defineInsert(schema, (q) =>
     q
       .insertInto("users")
       .values({ name: "Alice", email: "alice@example.com", age: 30, active: true })
       .returning((u) => ({ id: u.id, createdAt: u.createdAt })),
+  ),
   {},
 );
 
 // UPDATE
 const updatedCount = await executeUpdate(
   db,
-  schema,
-  (q) =>
+  defineUpdate(schema, (q) =>
     q
       .update("users")
       .set({ active: false })
       .where((u) => u.age > 65),
+  ),
   {},
 );
 
 // DELETE
 const deletedCount = await executeDelete(
   db,
-  schema,
-  (q) => q.deleteFrom("users").where((u) => !u.active),
+  defineDelete(schema, (q) => q.deleteFrom("users").where((u) => !u.active)),
   {},
 );
 
 // Generate SQL without executing
-const { sql, params } = selectStatement(
-  schema,
-  (q) => q.from("users").where((u) => u.email.endsWith("@example.com")),
+const { sql, params } = toSql(
+  defineSelect(schema, (q) => q.from("users").where((u) => u.email.endsWith("@example.com"))),
   {},
 );
 ```
@@ -577,7 +590,7 @@ const { sql, params } = selectStatement(
 ### 1.3 PostgreSQL Dialect Notes
 
 - Booleans map to `BOOLEAN` values (`true`/`false`).
-- Case-insensitive comparisons use `ILIKE` when you call helper functions such as `contains`.
+- Case-insensitive helper functions generate `LOWER()` comparisons for portable SQL.
 - RETURNING clauses are fully supported on INSERT, UPDATE, and DELETE through the execution helpers.
 - Parameter placeholders use the `$()` syntax expected by pg-promise (e.g., `$(minAge)`).
 - Window functions (`ROW_NUMBER()`, `RANK()`, `DENSE_RANK()`) are fully supported.
@@ -596,13 +609,19 @@ npm install @webpods/tinqer-sql-better-sqlite3 better-sqlite3
 
 ```typescript
 import Database from "better-sqlite3";
-import { createSchema } from "@webpods/tinqer";
+import {
+  createSchema,
+  defineSelect,
+  defineInsert,
+  defineUpdate,
+  defineDelete,
+} from "@webpods/tinqer";
 import {
   executeSelect,
   executeInsert,
   executeUpdate,
   executeDelete,
-  selectStatement,
+  toSql,
 } from "@webpods/tinqer-sql-better-sqlite3";
 
 interface Schema {
@@ -624,45 +643,46 @@ db.exec(`
 
 const inserted = executeInsert(
   db,
-  schema,
-  (q) => q.insertInto("users").values({ name: "Sam", email: "sam@example.com", age: 28 }),
+  defineInsert(schema, (q) =>
+    q.insertInto("users").values({ name: "Sam", email: "sam@example.com", age: 28 }),
+  ),
   {},
 );
 // inserted === 1
 
 const users = executeSelect(
   db,
-  schema,
-  (q, params) =>
+  defineSelect(schema, (q, params: { active: number }) =>
     q
       .from("users")
       .where((u) => u.isActive === params.active)
       .orderBy((u) => u.name),
+  ),
   { active: 1 },
 );
 
 const updated = executeUpdate(
   db,
-  schema,
-  (q) =>
+  defineUpdate(schema, (q) =>
     q
       .update("users")
       .set({ isActive: 0 })
       .where((u) => u.age > 60),
+  ),
   {},
 );
 
 const removed = executeDelete(
   db,
-  schema,
-  (q, params) => q.deleteFrom("users").where((u) => u.age < params.cutoff),
+  defineDelete(schema, (q, params: { cutoff: number }) =>
+    q.deleteFrom("users").where((u) => u.age < params.cutoff),
+  ),
   { cutoff: 18 },
 );
 
 // Need the SQL text for custom execution?
-const { sql, params } = selectStatement(
-  schema,
-  (q) => q.from("users").where((u) => u.name.startsWith("S")),
+const { sql, params } = toSql(
+  defineSelect(schema, (q) => q.from("users").where((u) => u.name.startsWith("S"))),
   {},
 );
 const rows = db.prepare(sql).all(params);
@@ -702,8 +722,8 @@ const rows = db.prepare(sql).all(params);
 Use query helpers for portable case-insensitive comparisons:
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
-import { selectStatement } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineSelect } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
   users: { id: number; name: string; email: string };
@@ -711,13 +731,13 @@ interface Schema {
 
 const schema = createSchema<Schema>();
 
-const { sql } = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const { sql } = toSql(
+  defineSelect(schema, (q, params, helpers) =>
     q.from("users").where((u) => helpers.functions.icontains(u.name, "alice")),
+  ),
   {},
 );
-// PostgreSQL: WHERE "name" ILIKE $(__p1)
+// PostgreSQL: WHERE LOWER("name") LIKE '%' || LOWER($(__p1)) || '%'
 // SQLite: WHERE LOWER("name") LIKE '%' || LOWER(@__p1) || '%'
 ```
 
@@ -738,13 +758,11 @@ Reference for adapter execution helpers, typed contexts, and query utilities.
 ## Table of Contents
 
 - [1. Execution APIs](#1-execution-apis)
-  - [1.1 selectStatement](#11-selectstatement)
-  - [1.2 executeSelect](#12-executeselect)
-  - [1.3 insertStatement & executeInsert](#13-insertstatement--executeinsert)
-  - [1.4 updateStatement & executeUpdate](#14-updatestatement--executeupdate)
-  - [1.5 deleteStatement & executeDelete](#15-deletestatement--executedelete)
-  - [1.6 toSql](#16-tosql)
-  - [1.7 ExecuteOptions & SqlResult](#17-executeoptions--sqlresult)
+  - [1.1 defineSelect, toSql & executeSelect](#11-defineselect-tosql--executeselect)
+  - [1.2 defineInsert, toSql & executeInsert](#12-defineinsert-tosql--executeinsert)
+  - [1.3 defineUpdate, toSql & executeUpdate](#13-defineupdate-tosql--executeupdate)
+  - [1.4 defineDelete, toSql & executeDelete](#14-definedelete-tosql--executedelete)
+  - [1.5 ExecuteOptions & SqlResult](#15-executeoptions--sqlresult)
 - [2. Type-Safe Contexts](#2-type-safe-contexts)
   - [2.1 createSchema](#21-createschema)
 - [3. Helper Utilities](#3-helper-utilities)
@@ -754,31 +772,51 @@ Reference for adapter execution helpers, typed contexts, and query utilities.
 
 ## 1. Execution APIs
 
-Adapter packages export the runtime helpers that turn expression trees into SQL and execute them. PostgreSQL helpers live in `@webpods/tinqer-sql-pg-promise`; SQLite helpers live in `@webpods/tinqer-sql-better-sqlite3` and expose the same signatures.
+Tinqer uses a two-step API:
 
-### 1.1 selectStatement
+1. **Plan definition** (`define*` functions from `@webpods/tinqer`) - Creates type-safe query plans
+2. **Execution or SQL generation** (`execute*` or `toSql` from adapter packages) - Executes plans or generates SQL
 
-Converts a query builder function into SQL and named parameters without executing it. The query builder receives a DSL context, parameters, and helper functions.
+Adapter packages live in `@webpods/tinqer-sql-pg-promise` (PostgreSQL) and `@webpods/tinqer-sql-better-sqlite3` (SQLite).
 
-**Signature**
+### 1.1 defineSelect, toSql & executeSelect
+
+Creates SELECT query plans, generates SQL, or executes queries.
+
+**Signatures**
 
 ```typescript
-function selectStatement<TSchema, TParams, TResult>(
+// Plan definition (from @webpods/tinqer)
+function defineSelect<TSchema, TParams, TResult>(
   schema: DatabaseSchema<TSchema>,
   queryBuilder: (
-    ctx: QueryBuilder<TSchema>,
+    q: QueryBuilder<TSchema>,
     params: TParams,
     helpers: QueryHelpers,
   ) => Queryable<TResult> | OrderedQueryable<TResult> | TerminalQuery<TResult>,
+  paramDefaults?: TParams,
+): SelectPlanHandle<TResult, TParams> | SelectTerminalHandle<TResult, TParams>;
+
+// SQL generation (from adapter packages)
+function toSql<TParams>(
+  plan: SelectPlanHandle<unknown, TParams> | SelectTerminalHandle<unknown, TParams>,
   params: TParams,
-): SqlResult<TParams & Record<string, unknown>, TResult>;
+): { sql: string; params: TParams & Record<string, unknown> };
+
+// Execution (from adapter packages)
+async function executeSelect<TResult, TParams>(
+  db: PgDatabase | BetterSqlite3Database,
+  plan: SelectPlanHandle<TResult, TParams> | SelectTerminalHandle<TResult, TParams>,
+  params: TParams,
+  options?: ExecuteOptions,
+): Promise<TResult[] | TResult>;
 ```
 
-**Example (PostgreSQL)**
+**Example - SQL Generation**
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
-import { selectStatement } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineSelect } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
   users: { id: number; name: string; age: number };
@@ -786,49 +824,23 @@ interface Schema {
 
 const schema = createSchema<Schema>();
 
-const { sql, params } = selectStatement(
-  schema,
-  (q, params) =>
+const { sql, params } = toSql(
+  defineSelect(schema, (q, params: { minAge: number }) =>
     q
       .from("users")
       .where((u) => u.age >= params.minAge)
       .select((u) => ({ id: u.id, name: u.name })),
+  ),
   { minAge: 18 },
 );
 // sql: SELECT "id" AS "id", "name" AS "name" FROM "users" WHERE "age" >= $(minAge)
 // params: { minAge: 18 }
 ```
 
-### 1.2 executeSelect
-
-Executes a query builder against the database and returns typed results. The query builder receives a DSL context, parameters, and helper functions.
+**Example - Execution**
 
 ```typescript
-async function executeSelect<
-  TSchema,
-  TParams,
-  TQuery extends Queryable<unknown> | OrderedQueryable<unknown> | TerminalQuery<unknown>,
->(
-  db: PgDatabase | BetterSqlite3Database,
-  schema: DatabaseSchema<TSchema>,
-  queryBuilder: (ctx: QueryBuilder<TSchema>, params: TParams, helpers: QueryHelpers) => TQuery,
-  params: TParams,
-  options?: ExecuteOptions,
-): Promise<
-  TQuery extends Queryable<infer T>
-    ? T[]
-    : TQuery extends OrderedQueryable<infer T>
-      ? T[]
-      : TQuery extends TerminalQuery<infer T>
-        ? T
-        : never
->;
-```
-
-**Example (PostgreSQL)**
-
-```typescript
-import { createSchema } from "@webpods/tinqer";
+import { createSchema, defineSelect } from "@webpods/tinqer";
 import { executeSelect } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
@@ -839,60 +851,76 @@ const schema = createSchema<Schema>();
 
 const users = await executeSelect(
   db,
-  schema,
-  (q, params) =>
+  defineSelect(schema, (q, params: { minAge: number }) =>
     q
       .from("users")
       .where((u) => u.age >= params.minAge)
       .orderBy((u) => u.name),
+  ),
   { minAge: 21 },
 );
+// Returns: Array of user objects
 ```
 
-### 1.3 insertStatement & executeInsert
+### 1.2 defineInsert, toSql & executeInsert
 
-Generate and execute INSERT statements with optional RETURNING clauses. The query builder receives a DSL context, parameters, and helper functions.
+Creates INSERT query plans, generates SQL, or executes queries with optional RETURNING clauses.
+
+**Signatures**
 
 ```typescript
-function insertStatement<TSchema, TParams, TTable, TReturning = never>(
+// Plan definition (from @webpods/tinqer)
+function defineInsert<TSchema, TParams, TTable, TReturning = never>(
   schema: DatabaseSchema<TSchema>,
   queryBuilder: (
-    ctx: QueryBuilder<TSchema>,
+    q: QueryBuilder<TSchema>,
     params: TParams,
     helpers: QueryHelpers,
   ) => Insertable<TTable> | InsertableWithReturning<TTable, TReturning>,
-  params: TParams,
-): SqlResult<TParams & Record<string, unknown>, TReturning extends never ? void : TReturning>;
+  paramDefaults?: TParams,
+): InsertPlanHandle<TTable, TReturning, TParams>;
 
-async function executeInsert<TSchema, TParams, TTable>(
+// SQL generation (from adapter packages)
+function toSql<TParams>(
+  plan: InsertPlanHandle<unknown, unknown, TParams>,
+  params: TParams,
+): { sql: string; params: TParams & Record<string, unknown> };
+
+// Execution (from adapter packages)
+async function executeInsert<TTable, TReturning, TParams>(
   db: PgDatabase | BetterSqlite3Database,
-  schema: DatabaseSchema<TSchema>,
-  queryBuilder: (
-    ctx: QueryBuilder<TSchema>,
-    params: TParams,
-    helpers: QueryHelpers,
-  ) => Insertable<TTable>,
+  plan: InsertPlanHandle<TTable, TReturning, TParams>,
   params: TParams,
   options?: ExecuteOptions,
-): Promise<number>;
-
-async function executeInsert<TSchema, TParams, TTable, TReturning>(
-  db: PgDatabase | BetterSqlite3Database,
-  schema: DatabaseSchema<TSchema>,
-  queryBuilder: (
-    ctx: QueryBuilder<TSchema>,
-    params: TParams,
-    helpers: QueryHelpers,
-  ) => InsertableWithReturning<TTable, TReturning>,
-  params: TParams,
-  options?: ExecuteOptions,
-): Promise<TReturning[]>;
+): Promise<TReturning extends never ? number : TReturning[]>;
 ```
 
-**Example**
+**Example - SQL Generation**
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
+import { createSchema, defineInsert } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
+
+interface Schema {
+  users: { id: number; name: string };
+}
+
+const schema = createSchema<Schema>();
+
+const { sql, params } = toSql(
+  defineInsert(schema, (q, params: { name: string }) =>
+    q.insertInto("users").values({ name: params.name }),
+  ),
+  { name: "Alice" },
+);
+// sql: INSERT INTO "users" ("name") VALUES ($(name))
+// params: { name: "Alice" }
+```
+
+**Example - Execution**
+
+```typescript
+import { createSchema, defineInsert } from "@webpods/tinqer";
 import { executeInsert } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
@@ -901,72 +929,93 @@ interface Schema {
 
 const schema = createSchema<Schema>();
 
-const inserted = await executeInsert(
+// Without RETURNING - returns number of rows inserted
+const rowCount = await executeInsert(
   db,
-  schema,
-  (q) => q.insertInto("users").values({ name: "Alice" }),
-  {},
+  defineInsert(schema, (q, params: { name: string }) =>
+    q.insertInto("users").values({ name: params.name }),
+  ),
+  { name: "Alice" },
 );
 
+// With RETURNING - returns inserted rows
 const createdUsers = await executeInsert(
   db,
-  schema,
-  (q) =>
+  defineInsert(schema, (q, params: { name: string }) =>
     q
       .insertInto("users")
-      .values({ name: "Bob" })
+      .values({ name: params.name })
       .returning((u) => ({ id: u.id, name: u.name })),
-  {},
+  ),
+  { name: "Bob" },
 );
 ```
 
-### 1.4 updateStatement & executeUpdate
+### 1.3 defineUpdate, toSql & executeUpdate
 
-Generate and execute UPDATE statements with optional RETURNING clauses. The query builder receives a DSL context, parameters, and helper functions.
+Creates UPDATE query plans, generates SQL, or executes queries with optional RETURNING clauses.
+
+**Signatures**
 
 ```typescript
-function updateStatement<TSchema, TParams, TTable, TReturning = never>(
+// Plan definition (from @webpods/tinqer)
+function defineUpdate<TSchema, TParams, TTable, TReturning = never>(
   schema: DatabaseSchema<TSchema>,
   queryBuilder: (
-    ctx: QueryBuilder<TSchema>,
+    q: QueryBuilder<TSchema>,
     params: TParams,
     helpers: QueryHelpers,
   ) =>
     | UpdatableWithSet<TTable>
     | UpdatableComplete<TTable>
     | UpdatableWithReturning<TTable, TReturning>,
-  params: TParams,
-): SqlResult<TParams & Record<string, unknown>, TReturning extends never ? void : TReturning>;
+  paramDefaults?: TParams,
+): UpdatePlanHandle<TTable, TReturning, TParams>;
 
-async function executeUpdate<TSchema, TParams, TTable>(
+// SQL generation (from adapter packages)
+function toSql<TParams>(
+  plan: UpdatePlanHandle<unknown, unknown, TParams>,
+  params: TParams,
+): { sql: string; params: TParams & Record<string, unknown> };
+
+// Execution (from adapter packages)
+async function executeUpdate<TTable, TReturning, TParams>(
   db: PgDatabase | BetterSqlite3Database,
-  schema: DatabaseSchema<TSchema>,
-  queryBuilder: (
-    ctx: QueryBuilder<TSchema>,
-    params: TParams,
-    helpers: QueryHelpers,
-  ) => UpdatableWithSet<TTable> | UpdatableComplete<TTable>,
+  plan: UpdatePlanHandle<TTable, TReturning, TParams>,
   params: TParams,
   options?: ExecuteOptions,
-): Promise<number>;
-
-async function executeUpdate<TSchema, TParams, TTable, TReturning>(
-  db: PgDatabase | BetterSqlite3Database,
-  schema: DatabaseSchema<TSchema>,
-  queryBuilder: (
-    ctx: QueryBuilder<TSchema>,
-    params: TParams,
-    helpers: QueryHelpers,
-  ) => UpdatableWithReturning<TTable, TReturning>,
-  params: TParams,
-  options?: ExecuteOptions,
-): Promise<TReturning[]>;
+): Promise<TReturning extends never ? number : TReturning[]>;
 ```
 
-**Example**
+**Example - SQL Generation**
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
+import { createSchema, defineUpdate } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
+
+interface Schema {
+  users: { id: number; name: string; status: string; lastLogin: Date };
+}
+
+const schema = createSchema<Schema>();
+
+const { sql, params } = toSql(
+  defineUpdate(schema, (q, params: { cutoff: Date }) =>
+    q
+      .update("users")
+      .set({ status: "inactive" })
+      .where((u) => u.lastLogin < params.cutoff),
+  ),
+  { cutoff: new Date("2024-01-01") },
+);
+// sql: UPDATE "users" SET "status" = 'inactive' WHERE "lastLogin" < $(cutoff)
+// params: { cutoff: Date }
+```
+
+**Example - Execution**
+
+```typescript
+import { createSchema, defineUpdate } from "@webpods/tinqer";
 import { executeUpdate } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
@@ -975,50 +1024,91 @@ interface Schema {
 
 const schema = createSchema<Schema>();
 
+// Without RETURNING - returns number of rows updated
 const updatedRows = await executeUpdate(
   db,
-  schema,
-  (q, params) =>
+  defineUpdate(schema, (q, params: { cutoff: Date }) =>
     q
       .update("users")
       .set({ status: "inactive" })
       .where((u) => u.lastLogin < params.cutoff),
+  ),
+  { cutoff: new Date("2024-01-01") },
+);
+
+// With RETURNING - returns updated rows
+const updatedUsers = await executeUpdate(
+  db,
+  defineUpdate(schema, (q, params: { cutoff: Date }) =>
+    q
+      .update("users")
+      .set({ status: "inactive" })
+      .where((u) => u.lastLogin < params.cutoff)
+      .returning((u) => ({ id: u.id, status: u.status })),
+  ),
   { cutoff: new Date("2024-01-01") },
 );
 ```
 
-### 1.5 deleteStatement & executeDelete
+### 1.4 defineDelete, toSql & executeDelete
 
-Generate and execute DELETE statements. The query builder receives a DSL context, parameters, and helper functions.
+Creates DELETE query plans, generates SQL, or executes queries.
+
+**Signatures**
 
 ```typescript
-function deleteStatement<TSchema, TParams, TResult>(
+// Plan definition (from @webpods/tinqer)
+function defineDelete<TSchema, TParams>(
   schema: DatabaseSchema<TSchema>,
   queryBuilder: (
-    ctx: QueryBuilder<TSchema>,
+    q: QueryBuilder<TSchema>,
     params: TParams,
     helpers: QueryHelpers,
-  ) => Deletable<TResult> | DeletableComplete<TResult>,
-  params: TParams,
-): SqlResult<TParams & Record<string, unknown>, void>;
+  ) => Deletable<unknown> | DeletableComplete<unknown>,
+  paramDefaults?: TParams,
+): DeletePlanHandle<TParams>;
 
-async function executeDelete<TSchema, TParams, TResult>(
+// SQL generation (from adapter packages)
+function toSql<TParams>(
+  plan: DeletePlanHandle<TParams>,
+  params: TParams,
+): { sql: string; params: TParams & Record<string, unknown> };
+
+// Execution (from adapter packages)
+async function executeDelete<TParams>(
   db: PgDatabase | BetterSqlite3Database,
-  schema: DatabaseSchema<TSchema>,
-  queryBuilder: (
-    ctx: QueryBuilder<TSchema>,
-    params: TParams,
-    helpers: QueryHelpers,
-  ) => Deletable<TResult> | DeletableComplete<TResult>,
+  plan: DeletePlanHandle<TParams>,
   params: TParams,
   options?: ExecuteOptions,
 ): Promise<number>;
 ```
 
-**Example**
+**Example - SQL Generation**
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
+import { createSchema, defineDelete } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
+
+interface Schema {
+  users: { id: number; name: string; status: string };
+}
+
+const schema = createSchema<Schema>();
+
+const { sql, params } = toSql(
+  defineDelete(schema, (q, params: { status: string }) =>
+    q.deleteFrom("users").where((u) => u.status === params.status),
+  ),
+  { status: "inactive" },
+);
+// sql: DELETE FROM "users" WHERE "status" = $(status)
+// params: { status: "inactive" }
+```
+
+**Example - Execution**
+
+```typescript
+import { createSchema, defineDelete } from "@webpods/tinqer";
 import { executeDelete } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
@@ -1029,48 +1119,14 @@ const schema = createSchema<Schema>();
 
 const deletedCount = await executeDelete(
   db,
-  schema,
-  (q) => q.deleteFrom("users").where((u) => u.status === "inactive"),
-  {},
+  defineDelete(schema, (q, params: { status: string }) =>
+    q.deleteFrom("users").where((u) => u.status === params.status),
+  ),
+  { status: "inactive" },
 );
 ```
 
-### 1.6 Statement Functions (selectStatement, insertStatement, etc.)
-
-Generate SQL and parameters without executing them. These functions are useful for debugging, testing, or when you need the SQL before execution.
-
-```typescript
-function selectStatement<TSchema, TResult>(
-  schema: DatabaseSchema<TSchema>,
-  builder: (q: QueryBuilder<TSchema>) => Queryable<TResult>,
-): SqlResult<Record<string, unknown>, TResult>;
-```
-
-**Example (SQLite)**
-
-```typescript
-import { createSchema } from "@webpods/tinqer";
-import { selectStatement } from "@webpods/tinqer-sql-better-sqlite3";
-
-interface Schema {
-  products: { id: number; name: string; price: number; inStock: number };
-}
-
-const schema = createSchema<Schema>();
-
-// Generate SQL without executing
-const result = selectStatement(schema, (q) =>
-  q
-    .from("products")
-    .where((p) => p.inStock === 1)
-    .orderByDescending((p) => p.price),
-);
-
-// result.sql contains the SQL string
-// result.params contains the parameters
-```
-
-### 1.7 ExecuteOptions & SqlResult
+### 1.5 ExecuteOptions & SqlResult
 
 Both adapters expose `ExecuteOptions` and `SqlResult` for inspection and typing.
 
@@ -1097,7 +1153,7 @@ Use `onSql` for logging, testing, or debugging without changing execution flow.
 Creates a phantom-typed `DatabaseSchema` that ties table names to row types. The schema is passed to execution functions, which provide a type-safe query builder through the lambda's first parameter.
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
+import { createSchema, defineSelect } from "@webpods/tinqer";
 import { executeSelect } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
@@ -1107,9 +1163,11 @@ interface Schema {
 
 const schema = createSchema<Schema>();
 
-// Schema is passed to execute functions, which provide the query builder 'q' parameter
-const results = await executeSelect(db, schema, (q) =>
-  q.from("users").where((u) => u.email.endsWith("@example.com")),
+// Schema is passed to defineSelect, which provides the query builder 'q' parameter
+const results = await executeSelect(
+  db,
+  defineSelect(schema, (q) => q.from("users").where((u) => u.email.endsWith("@example.com"))),
+  {},
 );
 ```
 
@@ -1122,8 +1180,8 @@ const results = await executeSelect(db, schema, (q) =>
 Provides helper functions for case-insensitive comparisons and string searches. Helpers are automatically passed as the third parameter to query builder functions.
 
 ```typescript
-import { createSchema, createQueryHelpers } from "@webpods/tinqer";
-import { selectStatement } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineSelect } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
   users: { id: number; name: string };
@@ -1131,10 +1189,10 @@ interface Schema {
 
 const schema = createSchema<Schema>();
 
-const result = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const result = toSql(
+  defineSelect(schema, (q, params, helpers) =>
     q.from("users").where((u) => helpers.functions.icontains(u.name, "alice")),
+  ),
   {},
 );
 ```
@@ -1340,8 +1398,8 @@ npm test
 ```typescript
 import { describe, it } from "mocha";
 import { strict as assert } from "assert";
-import { createSchema } from "@webpods/tinqer";
-import { selectStatement } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineSelect } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
 
 describe("SQL Generation", () => {
   it("should generate SQL with WHERE clause", () => {
@@ -1350,7 +1408,10 @@ describe("SQL Generation", () => {
     }
 
     const schema = createSchema<Schema>();
-    const result = selectStatement(schema, (q) => q.from("users").where((u) => u.age >= 18));
+    const result = toSql(
+      defineSelect(schema, (q) => q.from("users").where((u) => u.age >= 18)),
+      {},
+    );
 
     // Assert SQL and parameters
     assert.ok(result.sql.includes("WHERE"));
@@ -1364,7 +1425,7 @@ describe("SQL Generation", () => {
 ```typescript
 import { describe, it, beforeEach } from "mocha";
 import { strict as assert } from "assert";
-import { createSchema } from "@webpods/tinqer";
+import { createSchema, defineSelect } from "@webpods/tinqer";
 import { executeSelect } from "@webpods/tinqer-sql-pg-promise";
 import { db } from "./shared-db.js";
 
@@ -1379,12 +1440,12 @@ describe("PostgreSQL Integration", () => {
   it("should execute SELECT query", async () => {
     const results = await executeSelect(
       db,
-      schema,
-      (q, params) =>
+      defineSelect(schema, (q, params: { minAge: number }) =>
         q
           .from("users")
           .where((u) => u.age >= params.minAge)
           .select((u) => u.name),
+      ),
       { minAge: 25 },
     );
 
@@ -1632,13 +1693,13 @@ Error: Unsupported AST node type: TemplateLiteral
 // Incorrect - template literal in lambda
 .where(u => u.name === `User ${userId}`)
 
-// Correct - use params with executeSelect
+// Correct - use params with defineSelect and executeSelect
 await executeSelect(
   db,
-  schema,
-  (q, params) =>
+  defineSelect(schema, (q, params: { name: string }) =>
     q.from("users").where((u) => u.name === params.name),
-  { name: `User ${userId}` }
+  ),
+  { name: `User ${userId}` },
 );
 ```
 
@@ -1655,13 +1716,13 @@ Error: Unknown identifier 'externalVar'
 const minAge = 18;
 .where(u => u.age >= minAge)
 
-// Correct - params pattern with executeSelect
+// Correct - params pattern with defineSelect and executeSelect
 await executeSelect(
   db,
-  schema,
-  (q, params) =>
+  defineSelect(schema, (q, params: { minAge: number }) =>
     q.from("users").where((u) => u.age >= params.minAge),
-  { minAge: 18 }
+  ),
+  { minAge: 18 },
 );
 ```
 
@@ -1676,8 +1737,8 @@ const schema = createSchema(); // No schema type provided
 // Types will be 'unknown' without schema
 const result = await executeSelect(
   db,
-  schema,
-  (q) => q.from("users"), // Type is Queryable<unknown>
+  defineSelect(schema, (q) => q.from("users")), // Type is Queryable<unknown>
+  {},
 );
 ```
 
@@ -1693,8 +1754,8 @@ const schema = createSchema<Schema>();
 // Now fully typed from schema
 const result = await executeSelect(
   db,
-  schema,
-  (q) => q.from("users"), // Fully typed: Queryable<{ id: number; name: string }>
+  defineSelect(schema, (q) => q.from("users")), // Fully typed: Queryable<{ id: number; name: string }>
+  {},
 );
 ```
 
@@ -1816,7 +1877,8 @@ The `where` method applies predicates to filter query results. Multiple `where` 
 ### 1.1 Basic Comparison
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
+import { createSchema, defineSelect } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
   users: { id: number; name: string; age: number; email: string; active: boolean };
@@ -1824,7 +1886,10 @@ interface Schema {
 
 const schema = createSchema<Schema>();
 
-const adults = selectStatement(schema, (q) => q.from("users").where((u) => u.age >= 18), {});
+const adults = toSql(
+  defineSelect(schema, (q) => q.from("users").where((u) => u.age >= 18)),
+  {},
+);
 ```
 
 ```sql
@@ -1844,14 +1909,14 @@ SELECT * FROM "users" WHERE "age" >= @__p1
 ### 1.2 Multiple Predicates
 
 ```typescript
-const activeRange = selectStatement(
-  schema,
-  (q) =>
+const activeRange = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .where((u) => u.age >= 21)
       .where((u) => u.age <= 60)
       .where((u) => u.active === true),
+  ),
   {},
 );
 ```
@@ -1875,10 +1940,10 @@ WHERE "age" >= @__p1 AND "age" <= @__p2 AND "active" = @__p3
 ### 1.3 Logical Nesting and Arithmetic
 
 ```typescript
-const premium = selectStatement(
-  schema,
-  (q) =>
+const premium = toSql(
+  defineSelect(schema, (q) =>
     q.from("users").where((u) => (u.salary * 0.9 > 150_000 && u.age < 55) || u.active === false),
+  ),
   {},
 );
 ```
@@ -1902,9 +1967,8 @@ WHERE ((("salary" * @__p1) > @__p2 AND "age" < @__p3) OR "active" = @__p4)
 ### 1.4 Null Checks and Null Coalescing
 
 ```typescript
-const preferredName = selectStatement(
-  schema,
-  (q) => q.from("users").where((u) => (u.nickname ?? u.name) === "anonymous"),
+const preferredName = toSql(
+  defineSelect(schema, (q) => q.from("users").where((u) => (u.nickname ?? u.name) === "anonymous")),
   {},
 );
 ```
@@ -1926,14 +1990,14 @@ SELECT * FROM "users" WHERE COALESCE("nickname", "name") = @__p1
 ### 1.5 String Operations
 
 ```typescript
-const emailFilters = selectStatement(
-  schema,
-  (q) =>
+const emailFilters = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .where((u) => u.email.startsWith("admin"))
       .where((u) => u.email.endsWith("@example.com"))
       .where((u) => u.name.toLowerCase() === "john"),
+  ),
   {},
 );
 ```
@@ -1961,9 +2025,10 @@ WHERE "email" LIKE @__p1 || '%'
 ### 1.6 Case-Insensitive Helpers
 
 ```typescript
-const insensitive = selectStatement(
-  schema,
-  (q, params, helpers) => q.from("users").where((u) => helpers.functions.iequals(u.name, "ALICE")),
+const insensitive = toSql(
+  defineSelect(schema, (q, params, helpers) =>
+    q.from("users").where((u) => helpers.functions.iequals(u.name, "ALICE")),
+  ),
   {},
 );
 ```
@@ -1985,9 +2050,10 @@ SELECT * FROM "users" WHERE LOWER("name") = LOWER(@__p1)
 ### 1.7 Array Membership (IN)
 
 ```typescript
-const allowed = selectStatement(
-  schema,
-  (q) => q.from("users").where((u) => ["admin", "support", "auditor"].includes(u.role)),
+const allowed = toSql(
+  defineSelect(schema, (q) =>
+    q.from("users").where((u) => ["admin", "support", "auditor"].includes(u.role)),
+  ),
   {},
 );
 ```
@@ -2011,14 +2077,14 @@ Negating the predicate (`!array.includes(...)`) yields `NOT IN`.
 ### 1.8 Combined Filter Example
 
 ```typescript
-const advancedFilter = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const advancedFilter = toSql(
+  defineSelect(schema, (q, params: { minAge: number; categories: string[] }, helpers) =>
     q
       .from("users")
       .where((u) => u.age >= params.minAge)
       .where((u) => params.categories.includes(u.departmentId.toString()))
       .where((u) => helpers.functions.icontains(u.email, "company")),
+  ),
   { minAge: 25, categories: ["10", "11"] },
 );
 ```
@@ -2058,7 +2124,10 @@ The `select` method transforms query results by projecting columns or computed e
 ### 2.1 Full Row Projection
 
 ```typescript
-const fullRow = selectStatement(schema, (q) => q.from("users"), {});
+const fullRow = toSql(
+  defineSelect(schema, (q) => q.from("users")),
+  {},
+);
 ```
 
 ```sql
@@ -2074,9 +2143,8 @@ SELECT * FROM "users"
 ### 2.2 Object Projection
 
 ```typescript
-const summary = selectStatement(
-  schema,
-  (q) =>
+const summary = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .where((u) => u.active)
@@ -2087,6 +2155,7 @@ const summary = selectStatement(
           email: u.email,
         },
       })),
+  ),
   {},
 );
 ```
@@ -2109,14 +2178,14 @@ interface ProductSchema {
 }
 const schema = createSchema<ProductSchema>();
 
-const pricing = selectStatement(
-  schema,
-  (q) =>
+const pricing = toSql(
+  defineSelect(schema, (q) =>
     q.from("products").select((p) => ({
       id: p.id,
       name: p.name,
       effectivePrice: p.price - (p.discount ?? 0),
     })),
+  ),
   {},
 );
 ```
@@ -2144,7 +2213,10 @@ Methods `orderBy`, `orderByDescending`, `thenBy`, and `thenByDescending` control
 ### 3.1 Single Key Ascending
 
 ```typescript
-const alphabetical = selectStatement(schema, (q) => q.from("users").orderBy((u) => u.name), {});
+const alphabetical = toSql(
+  defineSelect(schema, (q) => q.from("users").orderBy((u) => u.name)),
+  {},
+);
 ```
 
 ```sql
@@ -2160,14 +2232,14 @@ SELECT * FROM "users" ORDER BY "name" ASC
 ### 3.2 Mixed Ordering
 
 ```typescript
-const ordered = selectStatement(
-  schema,
-  (q) =>
+const ordered = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .orderBy((u) => u.departmentId)
       .thenByDescending((u) => u.salary)
       .thenBy((u) => u.name),
+  ),
   {},
 );
 ```
@@ -2187,13 +2259,13 @@ SELECT * FROM "users" ORDER BY "departmentId" ASC, "salary" DESC, "name" ASC
 ## 4. Distinct Operations
 
 ```typescript
-const departments = selectStatement(
-  schema,
-  (q) =>
+const departments = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .select((u) => u.departmentId)
       .distinct(),
+  ),
   {},
 );
 ```
@@ -2217,14 +2289,14 @@ Methods `skip` and `take` implement OFFSET and LIMIT clauses.
 ### 5.1 Offset/Limit Pattern
 
 ```typescript
-const page = selectStatement(
-  schema,
-  (q) =>
+const page = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .orderBy((u) => u.id)
       .skip(30)
       .take(15),
+  ),
   {},
 );
 ```
@@ -2246,15 +2318,15 @@ SELECT * FROM "users" ORDER BY "id" ASC LIMIT @__p2 OFFSET @__p1
 ### 5.2 Pagination with Filtering
 
 ```typescript
-const filteredPage = selectStatement(
-  schema,
-  (q) =>
+const filteredPage = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .where((u) => u.active)
       .orderBy((u) => u.name)
       .skip(50)
       .take(25),
+  ),
   {},
 );
 ```
@@ -2288,15 +2360,15 @@ interface JoinSchema {
 }
 const schema = createSchema<JoinSchema>();
 
-const userDepartments = selectStatement(
-  schema,
-  (q) =>
+const userDepartments = toSql(
+  defineSelect(schema, (q) =>
     q.from("users").join(
       q.from("departments"),
       (u) => u.departmentId,
       (d) => d.id,
       (u, d) => ({ userName: u.name, departmentName: d.name }),
     ),
+  ),
   {},
 );
 ```
@@ -2324,9 +2396,8 @@ interface OrderSchema {
 }
 const schema = createSchema<OrderSchema>();
 
-const regionOrders = selectStatement(
-  schema,
-  (q) =>
+const regionOrders = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .where((u) => u.id > 100)
@@ -2337,6 +2408,7 @@ const regionOrders = selectStatement(
         (u, o) => ({ userName: u.name, total: o.total }),
       )
       .where((row) => row.total > 500),
+  ),
   {},
 );
 ```
@@ -2364,9 +2436,8 @@ WHERE "t0"."id" > @__p1 AND "t1"."total" > @__p2
 ### 6.3 Join with Grouped Results
 
 ```typescript
-const totalsByDepartment = selectStatement(
-  schema,
-  (q) =>
+const totalsByDepartment = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .join(
@@ -2381,6 +2452,7 @@ const totalsByDepartment = selectStatement(
         totalOrders: g.count(),
         revenue: g.sum((row) => row.o.total),
       })),
+  ),
   {},
 );
 ```
@@ -2406,9 +2478,8 @@ GROUP BY "t0"."departmentId"
 Model the classic LINQ pattern: start with `groupJoin`, then expand the grouped results with `selectMany(...defaultIfEmpty())`. Any missing matches appear as `null` in the projection.
 
 ```typescript
-const usersWithDepartments = selectStatement(
-  schema,
-  (q) =>
+const usersWithDepartments = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .groupJoin(
@@ -2425,6 +2496,7 @@ const usersWithDepartments = selectStatement(
         userId: row.user.id,
         departmentName: row.department ? row.department.name : null,
       })),
+  ),
   {},
 );
 ```
@@ -2448,9 +2520,8 @@ LEFT OUTER JOIN "departments" AS "t1" ON "t0"."departmentId" = "t1"."id"
 Return a `Queryable` from the collection selector passed to `selectMany`. Because we skip `defaultIfEmpty`, the parser normalizes the operation into a `CROSS JOIN`.
 
 ```typescript
-const departmentUsers = selectStatement(
-  schema,
-  (q) =>
+const departmentUsers = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("departments")
       .selectMany(
@@ -2461,6 +2532,7 @@ const departmentUsers = selectStatement(
         departmentId: row.department.id,
         userId: row.user.id,
       })),
+  ),
   {},
 );
 ```
@@ -2490,9 +2562,8 @@ The `groupBy` method groups results and enables aggregate functions: `count`, `s
 ### 7.1 Basic Grouping
 
 ```typescript
-const byDepartment = selectStatement(
-  schema,
-  (q) => q.from("users").groupBy((u) => u.departmentId),
+const byDepartment = toSql(
+  defineSelect(schema, (q) => q.from("users").groupBy((u) => u.departmentId)),
   {},
 );
 ```
@@ -2510,9 +2581,8 @@ SELECT "departmentId" FROM "users" GROUP BY "departmentId"
 ### 7.2 Group with Multiple Aggregates
 
 ```typescript
-const departmentStats = selectStatement(
-  schema,
-  (q) =>
+const departmentStats = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .groupBy((u) => u.departmentId)
@@ -2524,6 +2594,7 @@ const departmentStats = selectStatement(
         maxSalary: g.max((u) => u.salary),
       }))
       .orderByDescending((row) => row.totalSalary),
+  ),
   {},
 );
 ```
@@ -2549,13 +2620,13 @@ ORDER BY "totalSalary" DESC
 ```typescript
 const largeDepartments = await executeSelect(
   db,
-  schema,
-  (q) =>
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .groupBy((u) => u.departmentId)
       .select((g) => ({ departmentId: g.key, headcount: g.count() }))
       .where((row) => row.headcount > 5),
+  ),
   {},
 );
 ```
@@ -2584,9 +2655,8 @@ interface EmployeeSchema {
 }
 const schema = createSchema<EmployeeSchema>();
 
-const rankedEmployees = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const rankedEmployees = toSql(
+  defineSelect(schema, (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       department: e.department,
@@ -2597,6 +2667,7 @@ const rankedEmployees = selectStatement(
         .orderByDescending((r) => r.salary)
         .rowNumber(),
     })),
+  ),
   {},
 );
 ```
@@ -2623,9 +2694,8 @@ interface OrderTimeSchema {
 }
 const schema = createSchema<OrderTimeSchema>();
 
-const chronological = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const chronological = toSql(
+  defineSelect(schema, (q, params, helpers) =>
     q.from("orders").select((o) => ({
       orderId: o.id,
       rowNum: helpers
@@ -2633,6 +2703,7 @@ const chronological = selectStatement(
         .orderBy((r) => r.createdAt)
         .rowNumber(),
     })),
+  ),
   {},
 );
 ```
@@ -2651,9 +2722,8 @@ interface RegionEmployeeSchema {
 }
 const schema = createSchema<RegionEmployeeSchema>();
 
-const multiPartition = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const multiPartition = toSql(
+  defineSelect(schema, (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       rank: helpers
@@ -2665,6 +2735,7 @@ const multiPartition = selectStatement(
         .orderByDescending((r) => r.salary)
         .rowNumber(),
     })),
+  ),
   {},
 );
 ```
@@ -2679,9 +2750,8 @@ FROM "employees"
 #### Secondary Ordering with thenBy
 
 ```typescript
-const ranked = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const ranked = toSql(
+  defineSelect(schema, (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       rank: helpers
@@ -2691,6 +2761,7 @@ const ranked = selectStatement(
         .thenBy((r) => r.name)
         .rowNumber(),
     })),
+  ),
   {},
 );
 ```
@@ -2707,9 +2778,8 @@ FROM "employees"
 `RANK()` assigns ranks with gaps for tied values. If two rows have the same rank, the next rank skips numbers.
 
 ```typescript
-const rankedSalaries = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const rankedSalaries = toSql(
+  defineSelect(schema, (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       salary: e.salary,
@@ -2719,6 +2789,7 @@ const rankedSalaries = selectStatement(
         .orderByDescending((r) => r.salary)
         .rank(),
     })),
+  ),
   {},
 );
 ```
@@ -2755,9 +2826,8 @@ interface PlayerSchema {
 }
 const schema = createSchema<PlayerSchema>();
 
-const globalRank = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const globalRank = toSql(
+  defineSelect(schema, (q, params, helpers) =>
     q.from("players").select((p) => ({
       player: p.name,
       score: p.score,
@@ -2766,6 +2836,7 @@ const globalRank = selectStatement(
         .orderByDescending((r) => r.score)
         .rank(),
     })),
+  ),
   {},
 );
 ```
@@ -2781,9 +2852,8 @@ FROM "players"
 `DENSE_RANK()` assigns ranks without gaps. Tied values receive the same rank, and the next rank is consecutive.
 
 ```typescript
-const denseRanked = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const denseRanked = toSql(
+  defineSelect(schema, (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       salary: e.salary,
@@ -2793,6 +2863,7 @@ const denseRanked = selectStatement(
         .orderByDescending((r) => r.salary)
         .denseRank(),
     })),
+  ),
   {},
 );
 ```
@@ -2827,9 +2898,8 @@ interface EmployeeAgeSchema {
 }
 const schema = createSchema<EmployeeAgeSchema>();
 
-const complexRanking = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const complexRanking = toSql(
+  defineSelect(schema, (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       rank: helpers
@@ -2840,6 +2910,7 @@ const complexRanking = selectStatement(
         .thenBy((r) => r.name)
         .denseRank(),
     })),
+  ),
   {},
 );
 ```
@@ -2859,9 +2930,8 @@ FROM "employees"
 Combine multiple window functions in a single SELECT:
 
 ```typescript
-const allRankings = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const allRankings = toSql(
+  defineSelect(schema, (q, params, helpers) =>
     q.from("employees").select((e) => ({
       name: e.name,
       department: e.department,
@@ -2882,6 +2952,7 @@ const allRankings = selectStatement(
         .orderByDescending((r) => r.salary)
         .denseRank(),
     })),
+  ),
   {},
 );
 ```
@@ -2915,8 +2986,7 @@ Get the top earner from each department:
 ```typescript
 const topEarners = await executeSelect(
   db,
-  schema,
-  (q, params, helpers) =>
+  defineSelect(schema, (q, params, helpers) =>
     q
       .from("employees")
       .select((e) => ({
@@ -2929,6 +2999,7 @@ const topEarners = await executeSelect(
       }))
       .where((r) => r.rank === 1)
       .orderBy((r) => r.department),
+  ),
   {},
 );
 ```
@@ -2965,8 +3036,7 @@ const schema = createSchema<EmployeeDeptSchema>();
 
 const top3Engineering = await executeSelect(
   db,
-  schema,
-  (q, params, helpers) =>
+  defineSelect(schema, (q, params: { deptId: number }, helpers) =>
     q
       .from("employees")
       .select((e) => ({
@@ -2980,6 +3050,7 @@ const top3Engineering = await executeSelect(
       }))
       .where((r) => r.rank <= 3 && r.department_id === params.deptId)
       .orderBy((r) => r.rank),
+  ),
   { deptId: 1 },
 );
 ```
@@ -3007,8 +3078,7 @@ const schema = createSchema<PerformanceSchema>();
 
 const topPerformers = await executeSelect(
   db,
-  schema,
-  (q, params, helpers) =>
+  defineSelect(schema, (q, params, helpers) =>
     q
       .from("employees")
       .select((e) => ({
@@ -3019,6 +3089,7 @@ const topPerformers = await executeSelect(
           .rowNumber(),
       }))
       .where((r) => r.performance_rank <= 10),
+  ),
   {},
 );
 ```
@@ -3044,8 +3115,7 @@ const schema = createSchema<ActiveEmployeeSchema>();
 
 const activeTopEarners = await executeSelect(
   db,
-  schema,
-  (q, params, helpers) =>
+  defineSelect(schema, (q, params, helpers) =>
     q
       .from("employees")
       .select((e) => ({
@@ -3062,6 +3132,7 @@ const activeTopEarners = await executeSelect(
       .where((r) => r.dept_rank <= 2 && r.is_active === true)
       .orderBy((r) => r.department)
       .thenBy((r) => r.dept_rank),
+  ),
   {},
 );
 ```
@@ -3088,13 +3159,13 @@ ORDER BY "department" ASC, "dept_rank" ASC
 Aggregate methods can be called directly on queries to return single values.
 
 ```typescript
-const totals = selectStatement(
-  schema,
-  (q) =>
+const totals = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .where((u) => u.active === true)
       .sum((u) => u.salary),
+  ),
   {},
 );
 ```
@@ -3116,7 +3187,10 @@ SELECT SUM("salary") FROM "users" WHERE "active" = @__p1
 Methods `count`, `average`, `min`, and `max` follow the same structure. The `count` method also accepts a predicate:
 
 ```typescript
-const activeCount = selectStatement(schema, (q) => q.from("users").count((u) => u.active), {});
+const activeCount = toSql(
+  defineSelect(schema, (q) => q.from("users").count((u) => u.active)),
+  {},
+);
 ```
 
 ```sql
@@ -3138,7 +3212,10 @@ Methods `any` and `all` test whether elements satisfy conditions.
 ### 10.1 Any Operation
 
 ```typescript
-const hasAdults = selectStatement(schema, (q) => q.from("users").any((u) => u.age >= 18), {});
+const hasAdults = toSql(
+  defineSelect(schema, (q) => q.from("users").any((u) => u.age >= 18)),
+  {},
+);
 ```
 
 ```sql
@@ -3160,9 +3237,8 @@ SELECT CASE WHEN EXISTS(SELECT 1 FROM "users" WHERE "age" >= @__p1) THEN 1 ELSE 
 The `all` method emits a `NOT EXISTS` check:
 
 ```typescript
-const allActive = selectStatement(
-  schema,
-  (q) => q.from("users").all((u) => u.active === true),
+const allActive = toSql(
+  defineSelect(schema, (q) => q.from("users").all((u) => u.active === true)),
   {},
 );
 ```
@@ -3184,13 +3260,13 @@ SELECT CASE WHEN NOT EXISTS(SELECT 1 FROM "users" WHERE NOT ("active" = @__p1)) 
 Methods `first`, `firstOrDefault`, `single`, `singleOrDefault`, `last`, and `lastOrDefault` retrieve single elements.
 
 ```typescript
-const newestUser = selectStatement(
-  schema,
-  (q) =>
+const newestUser = toSql(
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .orderBy((u) => u.createdAt)
       .last(),
+  ),
   {},
 );
 ```
@@ -3218,12 +3294,12 @@ Queries are executed directly without requiring a materialization method. The qu
 ```typescript
 const activeUsers = await executeSelect(
   db,
-  schema,
-  (q) =>
+  defineSelect(schema, (q) =>
     q
       .from("users")
       .where((u) => u.active)
       .orderBy((u) => u.name),
+  ),
   {},
 );
 ```
@@ -3239,13 +3315,13 @@ Tinqer automatically parameterizes all values to prevent SQL injection and enabl
 ### 13.1 External Parameter Objects
 
 ```typescript
-const filtered = selectStatement(
-  schema,
-  (q, params) =>
+const filtered = toSql(
+  defineSelect(schema, (q, params: { minAge: number; role: string }) =>
     q
       .from("users")
       .where((u) => u.age >= params.minAge)
       .where((u) => u.role === params.role),
+  ),
   { minAge: 30, role: "manager" },
 );
 ```
@@ -3269,9 +3345,10 @@ Nested properties and array indices are preserved (`params.filters.departments[0
 ### 13.2 Literal Auto-Parameterisation
 
 ```typescript
-const autoParams = selectStatement(
-  schema,
-  (q) => q.from("users").where((u) => u.departmentId === 7 && u.name.startsWith("A")),
+const autoParams = toSql(
+  defineSelect(schema, (q) =>
+    q.from("users").where((u) => u.departmentId === 7 && u.name.startsWith("A")),
+  ),
   {},
 );
 ```
@@ -3293,9 +3370,8 @@ SELECT * FROM "users" WHERE "departmentId" = @__p1 AND "name" LIKE @__p2 || '%'
 ### 13.3 Array Membership
 
 ```typescript
-const membership = selectStatement(
-  schema,
-  (q) => q.from("users").where((u) => [1, 2, 3].includes(u.id)),
+const membership = toSql(
+  defineSelect(schema, (q) => q.from("users").where((u) => [1, 2, 3].includes(u.id))),
   {},
 );
 ```
@@ -3317,9 +3393,10 @@ SELECT * FROM "users" WHERE "id" IN (@__p1, @__p2, @__p3)
 Parameterized array example:
 
 ```typescript
-const dynamicMembership = selectStatement(
-  schema,
-  (q, params) => q.from("users").where((u) => params.allowed.includes(u.id)),
+const dynamicMembership = toSql(
+  defineSelect(schema, (q, params: { allowed: number[] }) =>
+    q.from("users").where((u) => params.allowed.includes(u.id)),
+  ),
   { allowed: [5, 8] },
 );
 ```
@@ -3331,10 +3408,10 @@ const dynamicMembership = selectStatement(
 ### 13.4 Case-Insensitive Helper Functions
 
 ```typescript
-const ic = selectStatement(
-  schema,
-  (q, params, helpers) =>
+const ic = toSql(
+  defineSelect(schema, (q, params, helpers) =>
     q.from("users").where((u) => helpers.functions.icontains(u.email, "support")),
+  ),
   {},
 );
 ```
@@ -3366,8 +3443,8 @@ The `insertInto` function creates INSERT operations. Values are specified using 
 #### Basic INSERT
 
 ```typescript
-import { createSchema, insertInto } from "@webpods/tinqer";
-import { insertStatement } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineInsert } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
   users: { id: number; name: string; age: number; email: string };
@@ -3375,14 +3452,14 @@ interface Schema {
 const schema = createSchema<Schema>();
 
 // Insert with literal values - direct object syntax
-const insert = insertStatement(
-  schema,
-  (q) =>
+const insert = toSql(
+  defineInsert(schema, (q) =>
     q.insertInto("users").values({
       name: "Alice",
       age: 30,
       email: "alice@example.com",
     }),
+  ),
   {},
 );
 ```
@@ -3404,14 +3481,14 @@ VALUES (@__p1, @__p2, @__p3)
 External variables must be passed via the params object - closure variables are not supported:
 
 ```typescript
-const insert = insertStatement(
-  schema,
-  (q, params) =>
+const insert = toSql(
+  defineInsert(schema, (q, params: { name: string; age: number }) =>
     q.insertInto("users").values({
       name: params.name,
       age: params.age,
       email: "default@example.com",
     }),
+  ),
   { name: "Bob", age: 25 },
 );
 ```
@@ -3432,24 +3509,26 @@ Both PostgreSQL and SQLite (3.35.0+) support the RETURNING clause to retrieve va
 
 ```typescript
 // Return specific columns
-const insertWithReturn = insertStatement(
-  schema,
-  (q) =>
+const insertWithReturn = toSql(
+  defineInsert(schema, (q) =>
     q
       .insertInto("users")
       .values({ name: "Charlie", age: 35 })
       .returning((u) => ({ id: u.id, createdAt: u.createdAt })),
+  ),
   {},
 );
 
 // Return all columns
-const insertReturnAll = insertStatement(
-  schema,
-  (q) =>
-    q
-      .insertInto("users")
-      .values({ name: "David", age: 40 })
-      .returning((u) => u), // Returns *
+const insertReturnAll = toSql(
+  defineInsert(
+    schema,
+    (q) =>
+      q
+        .insertInto("users")
+        .values({ name: "David", age: 40 })
+        .returning((u) => u), // Returns *
+  ),
   {},
 );
 ```
@@ -3457,14 +3536,14 @@ const insertReturnAll = insertStatement(
 #### NULL Values in INSERT
 
 ```typescript
-const insert = insertStatement(
-  schema,
-  (q) =>
+const insert = toSql(
+  defineInsert(schema, (q) =>
     q.insertInto("users").values({
       name: "Eve",
       email: null, // Generates NULL, not parameterized
       phone: undefined, // Column omitted from INSERT
     }),
+  ),
   {},
 );
 ```
@@ -3476,18 +3555,18 @@ The `update` function creates UPDATE operations. The `.set()` method uses direct
 #### Basic UPDATE
 
 ```typescript
-import { createSchema, update } from "@webpods/tinqer";
-import { updateStatement } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineUpdate } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
 
 const schema = createSchema<Schema>();
 
-const updateStmt = updateStatement(
-  schema,
-  (q) =>
+const updateStmt = toSql(
+  defineUpdate(schema, (q) =>
     q
       .update("users")
       .set({ age: 31, lastModified: new Date() })
       .where((u) => u.id === 1),
+  ),
   {},
 );
 ```
@@ -3513,13 +3592,13 @@ WHERE "id" = @__p3
 External variables must be passed via the params object:
 
 ```typescript
-const updateStmt = updateStatement(
-  schema,
-  (q, params) =>
+const updateStmt = toSql(
+  defineUpdate(schema, (q, params: { newAge: number }) =>
     q
       .update("users")
       .set({ age: params.newAge })
       .where((u) => u.id === 1),
+  ),
   { newAge: 32 },
 );
 ```
@@ -3527,13 +3606,13 @@ const updateStmt = updateStatement(
 #### UPDATE with Complex WHERE
 
 ```typescript
-const updateStmt = updateStatement(
-  schema,
-  (q) =>
+const updateStmt = toSql(
+  defineUpdate(schema, (q) =>
     q
       .update("users")
       .set({ status: "inactive" })
       .where((u) => u.lastLogin < new Date("2023-01-01") && u.role !== "admin"),
+  ),
   {},
 );
 ```
@@ -3541,14 +3620,14 @@ const updateStmt = updateStatement(
 #### UPDATE with RETURNING Clause
 
 ```typescript
-const updateWithReturn = updateStatement(
-  schema,
-  (q) =>
+const updateWithReturn = toSql(
+  defineUpdate(schema, (q) =>
     q
       .update("users")
       .set({ age: 32 })
       .where((u) => u.id === 2)
       .returning((u) => ({ id: u.id, age: u.age, updatedAt: u.updatedAt })),
+  ),
   {},
 );
 ```
@@ -3557,9 +3636,11 @@ const updateWithReturn = updateStatement(
 
 ```typescript
 // UPDATE without WHERE requires explicit permission
-const updateAll = updateStatement(
-  schema,
-  (q) => q.update("users").set({ isActive: true }).allowFullTableUpdate(), // Required flag
+const updateAll = toSql(
+  defineUpdate(
+    schema,
+    (q) => q.update("users").set({ isActive: true }).allowFullTableUpdate(), // Required flag
+  ),
   {},
 );
 ```
@@ -3578,12 +3659,15 @@ The `deleteFrom` function creates DELETE operations with optional WHERE conditio
 #### Basic DELETE
 
 ```typescript
-import { createSchema, deleteFrom } from "@webpods/tinqer";
-import { deleteStatement } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineDelete } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
 
 const schema = createSchema<Schema>();
 
-const del = deleteStatement(schema, (q) => q.deleteFrom("users").where((u) => u.age > 100), {});
+const del = toSql(
+  defineDelete(schema, (q) => q.deleteFrom("users").where((u) => u.age > 100)),
+  {},
+);
 ```
 
 Generated SQL:
@@ -3596,12 +3680,12 @@ DELETE FROM "users" WHERE "age" > @__p1    -- SQLite
 #### DELETE with Complex Conditions
 
 ```typescript
-const del = deleteStatement(
-  schema,
-  (q) =>
+const del = toSql(
+  defineDelete(schema, (q) =>
     q
       .deleteFrom("users")
       .where((u) => u.isDeleted === true || (u.age < 18 && u.role !== "admin") || u.email === null),
+  ),
   {},
 );
 ```
@@ -3609,9 +3693,10 @@ const del = deleteStatement(
 #### DELETE with IN Clause
 
 ```typescript
-const del = deleteStatement(
-  schema,
-  (q, params) => q.deleteFrom("users").where((u) => params.userIds.includes(u.id)),
+const del = toSql(
+  defineDelete(schema, (q, params: { userIds: number[] }) =>
+    q.deleteFrom("users").where((u) => params.userIds.includes(u.id)),
+  ),
   { userIds: [1, 2, 3, 4, 5] },
 );
 ```
@@ -3643,9 +3728,8 @@ WHERE "id" IN (@userIds_0, @userIds_1, @userIds_2, @userIds_3, @userIds_4)
 
 ```typescript
 // DELETE without WHERE requires explicit permission
-const deleteAll = deleteStatement(
-  schema,
-  (q) => q.deleteFrom("users").allowFullTableDelete(), // Required flag
+const deleteAll = toSql(
+  defineDelete(schema, (q) => q.deleteFrom("users").allowFullTableDelete()), // Required flag
   {},
 );
 ```
@@ -3660,11 +3744,17 @@ UPDATE and DELETE operations require WHERE clauses by default to prevent acciden
 
 ```typescript
 // This throws an error
-deleteStatement(schema, (q) => q.deleteFrom("users"), {});
+toSql(
+  defineDelete(schema, (q) => q.deleteFrom("users")),
+  {},
+);
 // Error: DELETE requires a WHERE clause or explicit allowFullTableDelete()
 
 // This works
-deleteStatement(schema, (q) => q.deleteFrom("users").allowFullTableDelete(), {});
+toSql(
+  defineDelete(schema, (q) => q.deleteFrom("users").allowFullTableDelete()),
+  {},
+);
 ```
 
 #### Type Safety
@@ -3678,22 +3768,22 @@ interface UserSchema {
 const schema = createSchema<UserSchema>();
 
 // Type error: 'username' doesn't exist on users table
-insertStatement(
-  schema,
-  (q) =>
+toSql(
+  defineInsert(schema, (q) =>
     q.insertInto("users").values({
       username: "Alice", // ❌ Type error
     }),
+  ),
   {},
 );
 
 // Type error: age must be number
-updateStatement(
-  schema,
-  (q) =>
+toSql(
+  defineUpdate(schema, (q) =>
     q.update("users").set({
       age: "30", // ❌ Type error - must be number
     }),
+  ),
   {},
 );
 ```
@@ -3704,12 +3794,12 @@ All values are automatically parameterized to prevent SQL injection:
 
 ```typescript
 const maliciousName = "'; DROP TABLE users; --";
-const insert = insertStatement(
-  schema,
-  (q) =>
+const insert = toSql(
+  defineInsert(schema, (q) =>
     q.insertInto("users").values({
       name: maliciousName, // Safely parameterized
     }),
+  ),
   {},
 );
 // Generates: INSERT INTO "users" ("name") VALUES ($(__p1))
@@ -3723,17 +3813,20 @@ The adapter packages provide execution functions for all CRUD operations:
 #### PostgreSQL (pg-promise)
 
 ```typescript
+import { createSchema, defineInsert, defineUpdate, defineDelete } from "@webpods/tinqer";
 import { executeInsert, executeUpdate, executeDelete } from "@webpods/tinqer-sql-pg-promise";
+
+const schema = createSchema<Schema>();
 
 // Execute INSERT with RETURNING
 const insertedUsers = await executeInsert(
   db,
-  schema,
-  (q) =>
+  defineInsert(schema, (q) =>
     q
       .insertInto("users")
       .values({ name: "Frank", age: 28 })
       .returning((u) => ({ id: u.id, name: u.name })),
+  ),
   {},
 );
 // Returns: [{ id: 123, name: "Frank" }]
@@ -3741,12 +3834,12 @@ const insertedUsers = await executeInsert(
 // Execute UPDATE - returns affected row count
 const updateCount = await executeUpdate(
   db,
-  schema,
-  (q) =>
+  defineUpdate(schema, (q) =>
     q
       .update("users")
       .set({ age: 29 })
       .where((u) => u.id === 123),
+  ),
   {},
 );
 // Returns number of affected rows
@@ -3754,8 +3847,7 @@ const updateCount = await executeUpdate(
 // Execute DELETE - returns affected row count
 const deleteCount = await executeDelete(
   db,
-  schema,
-  (q) => q.deleteFrom("users").where((u) => u.id === 123),
+  defineDelete(schema, (q) => q.deleteFrom("users").where((u) => u.id === 123)),
   {},
 );
 ```
@@ -3763,13 +3855,15 @@ const deleteCount = await executeDelete(
 #### SQLite (better-sqlite3)
 
 ```typescript
+import { createSchema, defineInsert, defineUpdate, defineDelete } from "@webpods/tinqer";
 import { executeInsert, executeUpdate, executeDelete } from "@webpods/tinqer-sql-better-sqlite3";
+
+const schema = createSchema<Schema>();
 
 // Execute INSERT - returns row count
 const insertCount = executeInsert(
   db,
-  schema,
-  (q) => q.insertInto("users").values({ name: "Grace", age: 30 }),
+  defineInsert(schema, (q) => q.insertInto("users").values({ name: "Grace", age: 30 })),
   {},
 );
 // Returns number of inserted rows
@@ -3777,25 +3871,24 @@ const insertCount = executeInsert(
 // Execute UPDATE - returns row count
 const updateCount = executeUpdate(
   db,
-  schema,
-  (q) =>
+  defineUpdate(schema, (q) =>
     q
       .update("users")
       .set({ age: 33 })
       .where((u) => u.name === "Henry"),
+  ),
   {},
 );
 
 // Execute DELETE - returns row count
 const deleteCount = executeDelete(
   db,
-  schema,
-  (q) => q.deleteFrom("users").where((u) => u.age > 100),
+  defineDelete(schema, (q) => q.deleteFrom("users").where((u) => u.age > 100)),
   {},
 );
 ```
 
-SQLite helpers always return the number of affected rows. To inspect row data after an insert or update, run a follow-up `selectStatement` query.
+SQLite helpers always return the number of affected rows. To inspect row data after an insert or update, run a follow-up SELECT query using `defineSelect` and `executeSelect`.
 
 #### Transaction Support
 
@@ -3812,38 +3905,42 @@ const schema = createSchema<TxSchema>();
 await db.tx(async (t) => {
   const users = await executeInsert(
     t,
-    schema,
-    (q) =>
+    defineInsert(schema, (q) =>
       q
         .insertInto("users")
         .values({ name: "Ivy" })
         .returning((u) => u.id),
+    ),
     {},
   );
 
   await executeInsert(
     t,
-    schema,
-    (q) =>
+    defineInsert(schema, (q) =>
       q.insertInto("user_logs").values({
         userId: users[0]!.id,
         action: "created",
       }),
+    ),
     {},
   );
 });
 
 // SQLite transactions
 const transaction = sqliteDb.transaction(() => {
-  executeInsert(db, schema, (q) => q.insertInto("users").values({ name: "Jack" }), {});
+  executeInsert(
+    db,
+    defineInsert(schema, (q) => q.insertInto("users").values({ name: "Jack" })),
+    {},
+  );
   executeUpdate(
     db,
-    schema,
-    (q) =>
+    defineUpdate(schema, (q) =>
       q
         .update("users")
         .set({ lastLogin: new Date() })
         .where((u) => u.name === "Jack"),
+    ),
     {},
   );
 });


### PR DESCRIPTION
Regenerate documentation site from tinqer repository version 0.0.20:
- Updated all HTML pages from latest markdown sources
- Updated llms.txt with latest API documentation
- Reflects removal of broken join methods from plan handles
- Includes updated Plan API examples using defineSelect and toSql

🤖 Generated with [Claude Code](https://claude.com/claude-code)