### PR TITLE
docs: update from tinqer 0.0.21

### DIFF
--- a/build/adapters.html
+++ b/build/adapters.html
@@ -90,13 +90,7 @@
 </code></pre>
 <h3 id="12-setup-%26-query-execution" tabindex="-1"><a class="anchor" href="#12-setup-%26-query-execution" aria-hidden="true">#</a> 1.2 Setup &amp; Query Execution</h3>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> pgPromise <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;pg-promise&quot;</span>;
-<span class="hljs-keyword">import</span> {
-  createSchema,
-  defineSelect,
-  defineInsert,
-  defineUpdate,
-  defineDelete,
-} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> {
   executeSelect,
   executeInsert,
@@ -116,55 +110,56 @@
 <span class="hljs-comment">// Execute with params</span>
 <span class="hljs-keyword">const</span> activeUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span> &amp;&amp; u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
-  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 
 <span class="hljs-comment">// Execute with params</span>
 <span class="hljs-keyword">const</span> matchingUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
-  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">21</span> },
 );
 
 <span class="hljs-comment">// INSERT with RETURNING</span>
 <span class="hljs-keyword">const</span> createdUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
   db,
-  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Alice&quot;</span>, <span class="hljs-attr">email</span>: <span class="hljs-string">&quot;alice@example.com&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">30</span>, <span class="hljs-attr">active</span>: <span class="hljs-literal">true</span> })
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">createdAt</span>: u.<span class="hljs-property">createdAt</span> })),
-  ),
   {},
 );
 
 <span class="hljs-comment">// UPDATE</span>
 <span class="hljs-keyword">const</span> updatedCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeUpdate</span>(
   db,
-  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">active</span>: <span class="hljs-literal">false</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">65</span>),
-  ),
   {},
 );
 
 <span class="hljs-comment">// DELETE</span>
 <span class="hljs-keyword">const</span> deletedCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeDelete</span>(
   db,
-  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> !u.<span class="hljs-property">active</span>)),
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> !u.<span class="hljs-property">active</span>),
   {},
 );
 
@@ -189,13 +184,7 @@
 </code></pre>
 <h3 id="22-setup-%26-query-execution" tabindex="-1"><a class="anchor" href="#22-setup-%26-query-execution" aria-hidden="true">#</a> 2.2 Setup &amp; Query Execution</h3>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> <span class="hljs-title class_">Database</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;better-sqlite3&quot;</span>;
-<span class="hljs-keyword">import</span> {
-  createSchema,
-  defineSelect,
-  defineInsert,
-  defineUpdate,
-  defineDelete,
-} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> {
   executeSelect,
   executeInsert,
@@ -223,40 +212,38 @@ db.<span class="hljs-title function_">exec</span>(<span class="hljs-string">`
 
 <span class="hljs-keyword">const</span> inserted = <span class="hljs-title function_">executeInsert</span>(
   db,
-  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
-    q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Sam&quot;</span>, <span class="hljs-attr">email</span>: <span class="hljs-string">&quot;sam@example.com&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">28</span> }),
-  ),
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Sam&quot;</span>, <span class="hljs-attr">email</span>: <span class="hljs-string">&quot;sam@example.com&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">28</span> }),
   {},
 );
 <span class="hljs-comment">// inserted === 1</span>
 
 <span class="hljs-keyword">const</span> users = <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { active: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { active: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">isActive</span> === params.<span class="hljs-property">active</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
-  ),
   { <span class="hljs-attr">active</span>: <span class="hljs-number">1</span> },
 );
 
 <span class="hljs-keyword">const</span> updated = <span class="hljs-title function_">executeUpdate</span>(
   db,
-  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">isActive</span>: <span class="hljs-number">0</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">60</span>),
-  ),
   {},
 );
 
 <span class="hljs-keyword">const</span> removed = <span class="hljs-title function_">executeDelete</span>(
   db,
-  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoff: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
-    q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt; params.<span class="hljs-property">cutoff</span>),
-  ),
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoff: <span class="hljs-built_in">number</span> }</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt; params.<span class="hljs-property">cutoff</span>),
   { <span class="hljs-attr">cutoff</span>: <span class="hljs-number">18</span> },
 );
 

--- a/build/api-reference.html
+++ b/build/api-reference.html
@@ -139,7 +139,7 @@
 <span class="hljs-comment">// params: { minAge: 18 }</span>
 </code></pre>
 <p><strong>Example - Execution</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -150,12 +150,12 @@
 
 <span class="hljs-keyword">const</span> users = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
-  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">21</span> },
 );
 <span class="hljs-comment">// Returns: Array of user objects</span>
@@ -208,7 +208,7 @@
 <span class="hljs-comment">// params: { name: &quot;Alice&quot; }</span>
 </code></pre>
 <p><strong>Example - Execution</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeInsert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -220,21 +220,20 @@
 <span class="hljs-comment">// Without RETURNING - returns number of rows inserted</span>
 <span class="hljs-keyword">const</span> rowCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
   db,
-  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { name: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
-    q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: params.<span class="hljs-property">name</span> }),
-  ),
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { name: <span class="hljs-built_in">string</span> }</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: params.<span class="hljs-property">name</span> }),
   { <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Alice&quot;</span> },
 );
 
 <span class="hljs-comment">// With RETURNING - returns inserted rows</span>
 <span class="hljs-keyword">const</span> createdUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
   db,
-  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { name: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { name: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: params.<span class="hljs-property">name</span> })
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
-  ),
   { <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Bob&quot;</span> },
 );
 </code></pre>
@@ -292,7 +291,7 @@
 <span class="hljs-comment">// params: { cutoff: Date }</span>
 </code></pre>
 <p><strong>Example - Execution</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineUpdate } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeUpdate } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -304,25 +303,25 @@
 <span class="hljs-comment">// Without RETURNING - returns number of rows updated</span>
 <span class="hljs-keyword">const</span> updatedRows = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeUpdate</span>(
   db,
-  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoff: <span class="hljs-built_in">Date</span> }</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoff: <span class="hljs-built_in">Date</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">lastLogin</span> &lt; params.<span class="hljs-property">cutoff</span>),
-  ),
   { <span class="hljs-attr">cutoff</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>(<span class="hljs-string">&quot;2024-01-01&quot;</span>) },
 );
 
 <span class="hljs-comment">// With RETURNING - returns updated rows</span>
 <span class="hljs-keyword">const</span> updatedUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeUpdate</span>(
   db,
-  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoff: <span class="hljs-built_in">Date</span> }</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoff: <span class="hljs-built_in">Date</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">lastLogin</span> &lt; params.<span class="hljs-property">cutoff</span>)
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">status</span>: u.<span class="hljs-property">status</span> })),
-  ),
   { <span class="hljs-attr">cutoff</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>(<span class="hljs-string">&quot;2024-01-01&quot;</span>) },
 );
 </code></pre>
@@ -374,7 +373,7 @@
 <span class="hljs-comment">// params: { status: &quot;inactive&quot; }</span>
 </code></pre>
 <p><strong>Example - Execution</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -385,9 +384,8 @@
 
 <span class="hljs-keyword">const</span> deletedCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeDelete</span>(
   db,
-  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { status: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
-    q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">status</span> === params.<span class="hljs-property">status</span>),
-  ),
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { status: <span class="hljs-built_in">string</span> }</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">status</span> === params.<span class="hljs-property">status</span>),
   { <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> },
 );
 </code></pre>
@@ -408,7 +406,7 @@
 <h2 id="2-type-safe-contexts" tabindex="-1"><a class="anchor" href="#2-type-safe-contexts" aria-hidden="true">#</a> 2. Type-Safe Contexts</h2>
 <h3 id="21-createschema" tabindex="-1"><a class="anchor" href="#21-createschema" aria-hidden="true">#</a> 2.1 createSchema</h3>
 <p>Creates a phantom-typed <code>DatabaseSchema</code> that ties table names to row types. The schema is passed to execution functions, which provide a type-safe query builder through the lambda’s first parameter.</p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -418,10 +416,11 @@
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
-<span class="hljs-comment">// Schema is passed to defineSelect, which provides the query builder &#x27;q&#x27; parameter</span>
+<span class="hljs-comment">// Schema is passed to executeSelect, which provides the query builder &#x27;q&#x27; parameter</span>
 <span class="hljs-keyword">const</span> results = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">email</span>.<span class="hljs-title function_">endsWith</span>(<span class="hljs-string">&quot;@example.com&quot;</span>))),
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">email</span>.<span class="hljs-title function_">endsWith</span>(<span class="hljs-string">&quot;@example.com&quot;</span>)),
   {},
 );
 </code></pre>

--- a/build/development.html
+++ b/build/development.html
@@ -246,7 +246,7 @@ npm <span class="hljs-built_in">test</span>
 <p><strong>Integration Test Example:</strong></p>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> { describe, it, beforeEach } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;mocha&quot;</span>;
 <span class="hljs-keyword">import</span> { strict <span class="hljs-keyword">as</span> assert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;assert&quot;</span>;
-<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 <span class="hljs-keyword">import</span> { db } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;./shared-db.js&quot;</span>;
 
@@ -261,12 +261,12 @@ npm <span class="hljs-built_in">test</span>
   <span class="hljs-title function_">it</span>(<span class="hljs-string">&quot;should execute SELECT query&quot;</span>, <span class="hljs-title function_">async</span> () =&gt; {
     <span class="hljs-keyword">const</span> results = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
       db,
-      <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+      schema,
+      <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
         q
           .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
           .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
           .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
-      ),
       { <span class="hljs-attr">minAge</span>: <span class="hljs-number">25</span> },
     );
 
@@ -472,12 +472,12 @@ pgp.<span class="hljs-title function_">end</span>(); <span class="hljs-comment">
 <pre class="hljs"><code><span class="hljs-comment">// Incorrect - template literal in lambda</span>
 .<span class="hljs-title function_">where</span>(<span class="hljs-function"><span class="hljs-params">u</span> =&gt;</span> u.<span class="hljs-property">name</span> === <span class="hljs-string">`User <span class="hljs-subst">${userId}</span>`</span>)
 
-<span class="hljs-comment">// Correct - use params with defineSelect and executeSelect</span>
+<span class="hljs-comment">// Correct - use params with executeSelect</span>
 <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { name: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { name: <span class="hljs-built_in">string</span> }</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span> === params.<span class="hljs-property">name</span>),
-  ),
   { <span class="hljs-attr">name</span>: <span class="hljs-string">`User <span class="hljs-subst">${userId}</span>`</span> },
 );
 </code></pre>
@@ -489,12 +489,12 @@ pgp.<span class="hljs-title function_">end</span>(); <span class="hljs-comment">
 <span class="hljs-keyword">const</span> minAge = <span class="hljs-number">18</span>;
 .<span class="hljs-title function_">where</span>(<span class="hljs-function"><span class="hljs-params">u</span> =&gt;</span> u.<span class="hljs-property">age</span> &gt;= minAge)
 
-<span class="hljs-comment">// Correct - params pattern with defineSelect and executeSelect</span>
+<span class="hljs-comment">// Correct - params pattern with executeSelect</span>
 <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>),
-  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 </code></pre>
@@ -506,7 +506,8 @@ pgp.<span class="hljs-title function_">end</span>(); <span class="hljs-comment">
 <span class="hljs-comment">// Types will be &#x27;unknown&#x27; without schema</span>
 <span class="hljs-keyword">const</span> result = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)), <span class="hljs-comment">// Type is Queryable&lt;unknown&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>), <span class="hljs-comment">// Type is Queryable&lt;unknown&gt;</span>
   {},
 );
 </code></pre>
@@ -520,7 +521,8 @@ pgp.<span class="hljs-title function_">end</span>(); <span class="hljs-comment">
 <span class="hljs-comment">// Now fully typed from schema</span>
 <span class="hljs-keyword">const</span> result = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)), <span class="hljs-comment">// Fully typed: Queryable&lt;{ id: number; name: string }&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>), <span class="hljs-comment">// Fully typed: Queryable&lt;{ id: number; name: string }&gt;</span>
   {},
 );
 </code></pre>

--- a/build/guide.html
+++ b/build/guide.html
@@ -143,6 +143,16 @@
 <li><a href="#145-executing-crud-operations">14.5 Executing CRUD Operations</a></li>
 </ul>
 </li>
+<li><a href="#15-query-composition-and-reusability">15. Query Composition and Reusability</a>
+<ul>
+<li><a href="#151-chaining-operations-on-plans">15.1 Chaining Operations on Plans</a></li>
+<li><a href="#152-immutability-and-base-queries">15.2 Immutability and Base Queries</a></li>
+<li><a href="#153-branching-from-base-queries">15.3 Branching from Base Queries</a></li>
+<li><a href="#154-parameter-accumulation">15.4 Parameter Accumulation</a></li>
+<li><a href="#155-composition-with-all-operations">15.5 Composition with All Operations</a></li>
+<li><a href="#156-practical-patterns">15.6 Practical Patterns</a></li>
+</ul>
+</li>
 </ul>
 <hr>
 <h2 id="1-filtering-operations" tabindex="-1"><a class="anchor" href="#1-filtering-operations" aria-hidden="true">#</a> 1. Filtering Operations</h2>
@@ -686,13 +696,13 @@
 <h3 id="73-group-with-post-filter" tabindex="-1"><a class="anchor" href="#73-group-with-post-filter" aria-hidden="true">#</a> 7.3 Group with Post-Filter</h3>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> largeDepartments = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">groupBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">g</span>) =&gt;</span> ({ <span class="hljs-attr">departmentId</span>: g.<span class="hljs-property">key</span>, <span class="hljs-attr">headcount</span>: g.<span class="hljs-title function_">count</span>() }))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">row</span>) =&gt;</span> row.<span class="hljs-property">headcount</span> &gt; <span class="hljs-number">5</span>),
-  ),
   {},
 );
 </code></pre>
@@ -1022,7 +1032,8 @@
 <p>Get the top earner from each department:</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> topEarners = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
@@ -1035,7 +1046,6 @@
       }))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">rank</span> === <span class="hljs-number">1</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">department</span>),
-  ),
   {},
 );
 </code></pre>
@@ -1064,7 +1074,8 @@
 
 <span class="hljs-keyword">const</span> top3Engineering = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { deptId: <span class="hljs-built_in">number</span> }, helpers</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { deptId: <span class="hljs-built_in">number</span> }, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
@@ -1078,7 +1089,6 @@
       }))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">rank</span> &lt;= <span class="hljs-number">3</span> &amp;&amp; r.<span class="hljs-property">department_id</span> === params.<span class="hljs-property">deptId</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">rank</span>),
-  ),
   { <span class="hljs-attr">deptId</span>: <span class="hljs-number">1</span> },
 );
 </code></pre>
@@ -1100,7 +1110,8 @@
 
 <span class="hljs-keyword">const</span> topPerformers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
@@ -1111,7 +1122,6 @@
           .<span class="hljs-title function_">rowNumber</span>(),
       }))
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">performance_rank</span> &lt;= <span class="hljs-number">10</span>),
-  ),
   {},
 );
 </code></pre>
@@ -1131,7 +1141,8 @@
 
 <span class="hljs-keyword">const</span> activeTopEarners = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, params, helpers</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
@@ -1148,7 +1159,6 @@
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">dept_rank</span> &lt;= <span class="hljs-number">2</span> &amp;&amp; r.<span class="hljs-property">is_active</span> === <span class="hljs-literal">true</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">department</span>)
       .<span class="hljs-title function_">thenBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">dept_rank</span>),
-  ),
   {},
 );
 </code></pre>
@@ -1255,12 +1265,12 @@
 <p>Queries are executed directly without requiring a materialization method. The query builder returns results as arrays by default.</p>
 <pre class="hljs"><code><span class="hljs-keyword">const</span> activeUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">active</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>),
-  ),
   {},
 );
 </code></pre>
@@ -1640,7 +1650,7 @@ Full table updates are dangerous and must be explicitly allowed.
 <h3 id="145-executing-crud-operations" tabindex="-1"><a class="anchor" href="#145-executing-crud-operations" aria-hidden="true">#</a> 14.5 Executing CRUD Operations</h3>
 <p>The adapter packages provide execution functions for all CRUD operations:</p>
 <h4 id="postgresql-(pg-promise)" tabindex="-1"><a class="anchor" href="#postgresql-(pg-promise)" aria-hidden="true">#</a> PostgreSQL (pg-promise)</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert, defineUpdate, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
@@ -1648,12 +1658,12 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-comment">// Execute INSERT with RETURNING</span>
 <span class="hljs-keyword">const</span> insertedUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
   db,
-  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Frank&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">28</span> })
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
-  ),
   {},
 );
 <span class="hljs-comment">// Returns: [{ id: 123, name: &quot;Frank&quot; }]</span>
@@ -1661,12 +1671,12 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-comment">// Execute UPDATE - returns affected row count</span>
 <span class="hljs-keyword">const</span> updateCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeUpdate</span>(
   db,
-  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: <span class="hljs-number">29</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">123</span>),
-  ),
   {},
 );
 <span class="hljs-comment">// Returns number of affected rows</span>
@@ -1674,12 +1684,13 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-comment">// Execute DELETE - returns affected row count</span>
 <span class="hljs-keyword">const</span> deleteCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeDelete</span>(
   db,
-  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">123</span>)),
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span> === <span class="hljs-number">123</span>),
   {},
 );
 </code></pre>
 <h4 id="sqlite-(better-sqlite3)" tabindex="-1"><a class="anchor" href="#sqlite-(better-sqlite3)" aria-hidden="true">#</a> SQLite (better-sqlite3)</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert, defineUpdate, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-better-sqlite3&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
@@ -1687,7 +1698,8 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-comment">// Execute INSERT - returns row count</span>
 <span class="hljs-keyword">const</span> insertCount = <span class="hljs-title function_">executeInsert</span>(
   db,
-  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Grace&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">30</span> })),
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Grace&quot;</span>, <span class="hljs-attr">age</span>: <span class="hljs-number">30</span> }),
   {},
 );
 <span class="hljs-comment">// Returns number of inserted rows</span>
@@ -1695,23 +1707,24 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-comment">// Execute UPDATE - returns row count</span>
 <span class="hljs-keyword">const</span> updateCount = <span class="hljs-title function_">executeUpdate</span>(
   db,
-  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">age</span>: <span class="hljs-number">33</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span> === <span class="hljs-string">&quot;Henry&quot;</span>),
-  ),
   {},
 );
 
 <span class="hljs-comment">// Execute DELETE - returns row count</span>
 <span class="hljs-keyword">const</span> deleteCount = <span class="hljs-title function_">executeDelete</span>(
   db,
-  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">100</span>)),
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">100</span>),
   {},
 );
 </code></pre>
-<p>SQLite helpers always return the number of affected rows. To inspect row data after an insert or update, run a follow-up SELECT query using <code>defineSelect</code> and <code>executeSelect</code>.</p>
+<p>SQLite helpers always return the number of affected rows. To inspect row data after an insert or update, run a follow-up SELECT query using <code>executeSelect</code>.</p>
 <h4 id="transaction-support" tabindex="-1"><a class="anchor" href="#transaction-support" aria-hidden="true">#</a> Transaction Support</h4>
 <p>Both adapters support transactions through their respective database drivers:</p>
 <pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">TxSchema</span> {
@@ -1724,47 +1737,303 @@ Full table updates are dangerous and must be explicitly allowed.
 <span class="hljs-keyword">await</span> db.<span class="hljs-title function_">tx</span>(<span class="hljs-title function_">async</span> (t) =&gt; {
   <span class="hljs-keyword">const</span> users = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
     t,
-    <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+    schema,
+    <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
       q
         .<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>)
         .<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Ivy&quot;</span> })
         .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span>),
-    ),
     {},
   );
 
   <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
     t,
-    <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+    schema,
+    <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
       q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;user_logs&quot;</span>).<span class="hljs-title function_">values</span>({
         <span class="hljs-attr">userId</span>: users[<span class="hljs-number">0</span>]!.<span class="hljs-property">id</span>,
         <span class="hljs-attr">action</span>: <span class="hljs-string">&quot;created&quot;</span>,
       }),
-    ),
     {},
   );
 });
 
 <span class="hljs-comment">// SQLite transactions</span>
 <span class="hljs-keyword">const</span> transaction = sqliteDb.<span class="hljs-title function_">transaction</span>(<span class="hljs-function">() =&gt;</span> {
-  <span class="hljs-title function_">executeInsert</span>(
-    db,
-    <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Jack&quot;</span> })),
-    {},
-  );
+  <span class="hljs-title function_">executeInsert</span>(db, schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({ <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Jack&quot;</span> }), {});
   <span class="hljs-title function_">executeUpdate</span>(
     db,
-    <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+    schema,
+    <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
       q
         .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
         .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">lastLogin</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>() })
         .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span> === <span class="hljs-string">&quot;Jack&quot;</span>),
-    ),
     {},
   );
 });
 <span class="hljs-title function_">transaction</span>();
 </code></pre>
+<hr>
+<h2 id="15-query-composition-and-reusability" tabindex="-1"><a class="anchor" href="#15-query-composition-and-reusability" aria-hidden="true">#</a> 15. Query Composition and Reusability</h2>
+<p>Tinqer query plans are <strong>immutable and composable</strong>. Plan handles returned by <code>define*</code> functions support method chaining - each operation returns a new plan without modifying the original. This enables powerful query composition patterns: reusable base queries, branching specialized variations, and parameter accumulation.</p>
+<h3 id="151-chaining-operations-on-plans" tabindex="-1"><a class="anchor" href="#151-chaining-operations-on-plans" aria-hidden="true">#</a> 15.1 Chaining Operations on Plans</h3>
+<p>All plan handles support chaining operations like <code>where()</code>, <code>orderBy()</code>, <code>select()</code>, etc.:</p>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+
+<span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
+  <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">isActive</span>: <span class="hljs-built_in">boolean</span> };
+}
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
+
+<span class="hljs-comment">// Chain operations on the plan handle</span>
+<span class="hljs-keyword">const</span> plan = <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>))
+  .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">18</span>)
+  .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">isActive</span> === <span class="hljs-literal">true</span>)
+  .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>)
+  .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> }));
+
+<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">toSql</span>(plan, {});
+<span class="hljs-comment">// SELECT &quot;id&quot; AS &quot;id&quot;, &quot;name&quot; AS &quot;name&quot; FROM &quot;users&quot;</span>
+<span class="hljs-comment">// WHERE &quot;age&quot; &gt; $(__p1) AND &quot;isActive&quot; = $(__p2)</span>
+<span class="hljs-comment">// ORDER BY &quot;name&quot; ASC</span>
+</code></pre>
+<h3 id="152-immutability-and-base-queries" tabindex="-1"><a class="anchor" href="#152-immutability-and-base-queries" aria-hidden="true">#</a> 15.2 Immutability and Base Queries</h3>
+<p>Plans are immutable - calling a method returns a <strong>new plan</strong> without modifying the original:</p>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> basePlan = <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>));
+
+<span class="hljs-keyword">const</span> withAge = basePlan.<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">18</span>);
+<span class="hljs-keyword">const</span> withStatus = basePlan.<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">isActive</span> === <span class="hljs-literal">true</span>);
+
+<span class="hljs-comment">// basePlan is unchanged</span>
+<span class="hljs-comment">// withAge and withStatus are independent plans</span>
+</code></pre>
+<p>This immutability enables creating <strong>reusable base queries</strong>:</p>
+<pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
+  <span class="hljs-attr">orders</span>: {
+    <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>;
+    <span class="hljs-attr">userId</span>: <span class="hljs-built_in">number</span>;
+    <span class="hljs-attr">total</span>: <span class="hljs-built_in">number</span>;
+    <span class="hljs-attr">status</span>: <span class="hljs-built_in">string</span>;
+    <span class="hljs-attr">createdAt</span>: <span class="hljs-title class_">Date</span>;
+  };
+}
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
+
+<span class="hljs-comment">// Reusable base query</span>
+<span class="hljs-keyword">type</span> <span class="hljs-title class_">UserOrdersParams</span> = { <span class="hljs-attr">userId</span>: <span class="hljs-built_in">number</span> };
+
+<span class="hljs-keyword">const</span> userOrders = <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">p</span>: <span class="hljs-title class_">UserOrdersParams</span></span>) =&gt;</span>
+  q
+    .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;orders&quot;</span>)
+    .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">o</span>) =&gt;</span> o.<span class="hljs-property">userId</span> === p.<span class="hljs-property">userId</span>)
+    .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">o</span>) =&gt;</span> o.<span class="hljs-property">createdAt</span>),
+);
+
+<span class="hljs-comment">// Use the base query in different contexts</span>
+<span class="hljs-keyword">const</span> recentUserOrders = userOrders.<span class="hljs-title function_">take</span>(<span class="hljs-number">10</span>);
+<span class="hljs-keyword">const</span> highValueUserOrders = userOrders.<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">o</span>) =&gt;</span> o.<span class="hljs-property">total</span> &gt; <span class="hljs-number">1000</span>);
+
+<span class="hljs-comment">// Execute with parameters</span>
+<span class="hljs-title function_">toSql</span>(recentUserOrders, { <span class="hljs-attr">userId</span>: <span class="hljs-number">42</span> });
+<span class="hljs-title function_">toSql</span>(highValueUserOrders, { <span class="hljs-attr">userId</span>: <span class="hljs-number">42</span> });
+</code></pre>
+<h3 id="153-branching-from-base-queries" tabindex="-1"><a class="anchor" href="#153-branching-from-base-queries" aria-hidden="true">#</a> 15.3 Branching from Base Queries</h3>
+<p>Since plans are immutable, you can branch multiple specialized queries from a single base:</p>
+<pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
+  <span class="hljs-attr">users</span>: {
+    <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>;
+    <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>;
+    <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span>;
+    <span class="hljs-attr">isActive</span>: <span class="hljs-built_in">boolean</span>;
+    <span class="hljs-attr">departmentId</span>: <span class="hljs-built_in">number</span>;
+  };
+}
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
+
+<span class="hljs-keyword">type</span> <span class="hljs-title class_">DeptParams</span> = { <span class="hljs-attr">departmentId</span>: <span class="hljs-built_in">number</span> };
+
+<span class="hljs-comment">// Base query: users in a department</span>
+<span class="hljs-keyword">const</span> usersInDept = <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">p</span>: <span class="hljs-title class_">DeptParams</span></span>) =&gt;</span>
+  q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span> === p.<span class="hljs-property">departmentId</span>),
+);
+
+<span class="hljs-comment">// Branch 1: Active users only</span>
+<span class="hljs-keyword">const</span> activeUsersInDept = usersInDept
+  .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">isActive</span> === <span class="hljs-literal">true</span>)
+  .<span class="hljs-property">where</span>&lt;{ <span class="hljs-attr">minAge</span>: <span class="hljs-built_in">number</span> }&gt;(<span class="hljs-function">(<span class="hljs-params">u, p</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= p.<span class="hljs-property">minAge</span>)
+  .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>);
+
+<span class="hljs-comment">// Branch 2: Inactive users only</span>
+<span class="hljs-keyword">const</span> inactiveUsersInDept = usersInDept
+  .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">isActive</span> === <span class="hljs-literal">false</span>)
+  .<span class="hljs-property">where</span>&lt;{ <span class="hljs-attr">maxAge</span>: <span class="hljs-built_in">number</span> }&gt;(<span class="hljs-function">(<span class="hljs-params">u, p</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt;= p.<span class="hljs-property">maxAge</span>)
+  .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span>);
+
+<span class="hljs-comment">// Branch 3: Senior staff</span>
+<span class="hljs-keyword">const</span> seniorStaffInDept = usersInDept
+  .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= <span class="hljs-number">50</span>)
+  .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span>, <span class="hljs-attr">age</span>: u.<span class="hljs-property">age</span> }));
+
+<span class="hljs-comment">// Execute branches with different parameters</span>
+<span class="hljs-title function_">toSql</span>(activeUsersInDept, { <span class="hljs-attr">departmentId</span>: <span class="hljs-number">1</span>, <span class="hljs-attr">minAge</span>: <span class="hljs-number">25</span> });
+<span class="hljs-title function_">toSql</span>(inactiveUsersInDept, { <span class="hljs-attr">departmentId</span>: <span class="hljs-number">1</span>, <span class="hljs-attr">maxAge</span>: <span class="hljs-number">65</span> });
+<span class="hljs-title function_">toSql</span>(seniorStaffInDept, { <span class="hljs-attr">departmentId</span>: <span class="hljs-number">1</span> });
+</code></pre>
+<h3 id="154-parameter-accumulation" tabindex="-1"><a class="anchor" href="#154-parameter-accumulation" aria-hidden="true">#</a> 15.4 Parameter Accumulation</h3>
+<p>Parameters from the builder function and chained operations are <strong>merged automatically</strong>:</p>
+<pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
+  <span class="hljs-attr">products</span>: {
+    <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>;
+    <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>;
+    <span class="hljs-attr">price</span>: <span class="hljs-built_in">number</span>;
+    <span class="hljs-attr">category</span>: <span class="hljs-built_in">string</span>;
+    <span class="hljs-attr">inStock</span>: <span class="hljs-built_in">boolean</span>;
+  };
+}
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
+
+<span class="hljs-comment">// Builder function defines initial params</span>
+<span class="hljs-keyword">type</span> <span class="hljs-title class_">BuilderParams</span> = { <span class="hljs-attr">category</span>: <span class="hljs-built_in">string</span> };
+
+<span class="hljs-keyword">const</span> plan = <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">p</span>: <span class="hljs-title class_">BuilderParams</span></span>) =&gt;</span>
+  q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;products&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">prod</span>) =&gt;</span> prod.<span class="hljs-property">category</span> === p.<span class="hljs-property">category</span>),
+);
+
+<span class="hljs-comment">// Chained operations add more params</span>
+<span class="hljs-keyword">type</span> <span class="hljs-title class_">ChainParams1</span> = { <span class="hljs-attr">minPrice</span>: <span class="hljs-built_in">number</span> };
+<span class="hljs-keyword">type</span> <span class="hljs-title class_">ChainParams2</span> = { <span class="hljs-attr">maxPrice</span>: <span class="hljs-built_in">number</span> };
+
+<span class="hljs-keyword">const</span> refinedPlan = plan
+  .<span class="hljs-property">where</span>&lt;<span class="hljs-title class_">ChainParams1</span>&gt;(<span class="hljs-function">(<span class="hljs-params">prod, p</span>) =&gt;</span> prod.<span class="hljs-property">price</span> &gt;= p.<span class="hljs-property">minPrice</span>)
+  .<span class="hljs-property">where</span>&lt;<span class="hljs-title class_">ChainParams2</span>&gt;(<span class="hljs-function">(<span class="hljs-params">prod, p</span>) =&gt;</span> prod.<span class="hljs-property">price</span> &lt;= p.<span class="hljs-property">maxPrice</span>)
+  .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">prod</span>) =&gt;</span> prod.<span class="hljs-property">inStock</span> === <span class="hljs-literal">true</span>);
+
+<span class="hljs-comment">// Must provide ALL accumulated parameters</span>
+<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">toSql</span>(refinedPlan, {
+  <span class="hljs-attr">category</span>: <span class="hljs-string">&quot;electronics&quot;</span>,
+  <span class="hljs-attr">minPrice</span>: <span class="hljs-number">100</span>,
+  <span class="hljs-attr">maxPrice</span>: <span class="hljs-number">1000</span>,
+});
+
+<span class="hljs-comment">// params contains: { category, minPrice, maxPrice, __p1: true }</span>
+</code></pre>
+<p><strong>Type safety</strong>: TypeScript enforces that all accumulated parameters are provided at execution time.</p>
+<h3 id="155-composition-with-all-operations" tabindex="-1"><a class="anchor" href="#155-composition-with-all-operations" aria-hidden="true">#</a> 15.5 Composition with All Operations</h3>
+<p>Composition works with all CRUD operations, not just SELECT:</p>
+<h4 id="insert-composition" tabindex="-1"><a class="anchor" href="#insert-composition" aria-hidden="true">#</a> INSERT Composition</h4>
+<pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
+  <span class="hljs-attr">posts</span>: {
+    <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>;
+    <span class="hljs-attr">userId</span>: <span class="hljs-built_in">number</span>;
+    <span class="hljs-attr">title</span>: <span class="hljs-built_in">string</span>;
+    <span class="hljs-attr">content</span>: <span class="hljs-built_in">string</span>;
+    <span class="hljs-attr">isPublished</span>: <span class="hljs-built_in">boolean</span>;
+  };
+}
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
+
+<span class="hljs-keyword">const</span> insertPost = <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;posts&quot;</span>))
+  .<span class="hljs-title function_">values</span>({
+    <span class="hljs-attr">userId</span>: <span class="hljs-number">1</span>,
+    <span class="hljs-attr">title</span>: <span class="hljs-string">&quot;My Post&quot;</span>,
+    <span class="hljs-attr">content</span>: <span class="hljs-string">&quot;Post content&quot;</span>,
+    <span class="hljs-attr">isPublished</span>: <span class="hljs-literal">false</span>,
+  })
+  .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: p.<span class="hljs-property">id</span>, <span class="hljs-attr">title</span>: p.<span class="hljs-property">title</span> }));
+
+<span class="hljs-title function_">toSql</span>(insertPost, {});
+</code></pre>
+<h4 id="update-composition" tabindex="-1"><a class="anchor" href="#update-composition" aria-hidden="true">#</a> UPDATE Composition</h4>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> updatePlan = <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;posts&quot;</span>))
+  .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">isPublished</span>: <span class="hljs-literal">true</span> })
+  .<span class="hljs-property">where</span>&lt;{ <span class="hljs-attr">minViews</span>: <span class="hljs-built_in">number</span> }&gt;(<span class="hljs-function">(<span class="hljs-params">p, params</span>) =&gt;</span> p.<span class="hljs-property">viewCount</span> &gt; params.<span class="hljs-property">minViews</span>)
+  .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> p.<span class="hljs-property">id</span>);
+
+<span class="hljs-title function_">toSql</span>(updatePlan, { <span class="hljs-attr">minViews</span>: <span class="hljs-number">1000</span> });
+</code></pre>
+<h4 id="delete-composition" tabindex="-1"><a class="anchor" href="#delete-composition" aria-hidden="true">#</a> DELETE Composition</h4>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> deletePlan = <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;posts&quot;</span>))
+  .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">p</span>) =&gt;</span> p.<span class="hljs-property">isPublished</span> === <span class="hljs-literal">false</span>)
+  .<span class="hljs-property">where</span>&lt;{ <span class="hljs-attr">beforeDate</span>: <span class="hljs-title class_">Date</span> }&gt;(<span class="hljs-function">(<span class="hljs-params">p, params</span>) =&gt;</span> p.<span class="hljs-property">createdAt</span> &lt; params.<span class="hljs-property">beforeDate</span>);
+
+<span class="hljs-title function_">toSql</span>(deletePlan, { <span class="hljs-attr">beforeDate</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>(<span class="hljs-string">&quot;2024-01-01&quot;</span>) });
+</code></pre>
+<h3 id="156-practical-patterns" tabindex="-1"><a class="anchor" href="#156-practical-patterns" aria-hidden="true">#</a> 15.6 Practical Patterns</h3>
+<h4 id="pattern-1%3A-pagination-helper" tabindex="-1"><a class="anchor" href="#pattern-1%3A-pagination-helper" aria-hidden="true">#</a> Pattern 1: Pagination Helper</h4>
+<pre class="hljs"><code><span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
+  <span class="hljs-attr">articles</span>: {
+    <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>;
+    <span class="hljs-attr">title</span>: <span class="hljs-built_in">string</span>;
+    <span class="hljs-attr">createdAt</span>: <span class="hljs-title class_">Date</span>;
+    <span class="hljs-attr">viewCount</span>: <span class="hljs-built_in">number</span>;
+  };
+}
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
+
+<span class="hljs-keyword">type</span> <span class="hljs-title class_">PageParams</span> = { <span class="hljs-attr">page</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">pageSize</span>: <span class="hljs-built_in">number</span> };
+
+<span class="hljs-keyword">function</span> paginate&lt;<span class="hljs-title class_">TPlan</span> <span class="hljs-keyword">extends</span> { <span class="hljs-attr">skip</span>: <span class="hljs-title class_">Function</span>; <span class="hljs-attr">take</span>: <span class="hljs-title class_">Function</span> }&gt;(
+  <span class="hljs-attr">plan</span>: <span class="hljs-title class_">TPlan</span>,
+  <span class="hljs-attr">page</span>: <span class="hljs-built_in">number</span>,
+  <span class="hljs-attr">pageSize</span>: <span class="hljs-built_in">number</span>,
+): <span class="hljs-title class_">TPlan</span> {
+  <span class="hljs-keyword">return</span> plan.<span class="hljs-title function_">skip</span>((page - <span class="hljs-number">1</span>) * pageSize).<span class="hljs-title function_">take</span>(pageSize) <span class="hljs-keyword">as</span> <span class="hljs-title class_">TPlan</span>;
+}
+
+<span class="hljs-keyword">const</span> allArticles = <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;articles&quot;</span>).<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">a</span>) =&gt;</span> a.<span class="hljs-property">createdAt</span>));
+
+<span class="hljs-comment">// Page 1</span>
+<span class="hljs-keyword">const</span> page1 = <span class="hljs-title function_">paginate</span>(allArticles, <span class="hljs-number">1</span>, <span class="hljs-number">20</span>);
+<span class="hljs-title function_">toSql</span>(page1, {});
+
+<span class="hljs-comment">// Page 2</span>
+<span class="hljs-keyword">const</span> page2 = <span class="hljs-title function_">paginate</span>(allArticles, <span class="hljs-number">2</span>, <span class="hljs-number">20</span>);
+<span class="hljs-title function_">toSql</span>(page2, {});
+</code></pre>
+<h4 id="pattern-2%3A-common-filters" tabindex="-1"><a class="anchor" href="#pattern-2%3A-common-filters" aria-hidden="true">#</a> Pattern 2: Common Filters</h4>
+<pre class="hljs"><code><span class="hljs-keyword">const</span> activeArticles = <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;articles&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">a</span>) =&gt;</span> a.<span class="hljs-property">isActive</span> === <span class="hljs-literal">true</span>),
+);
+
+<span class="hljs-keyword">const</span> popularActiveArticles = activeArticles.<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">a</span>) =&gt;</span> a.<span class="hljs-property">viewCount</span> &gt; <span class="hljs-number">1000</span>);
+
+<span class="hljs-keyword">const</span> recentActiveArticles = activeArticles
+  .<span class="hljs-property">where</span>&lt;{ <span class="hljs-attr">since</span>: <span class="hljs-title class_">Date</span> }&gt;(<span class="hljs-function">(<span class="hljs-params">a, p</span>) =&gt;</span> a.<span class="hljs-property">createdAt</span> &gt;= p.<span class="hljs-property">since</span>)
+  .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">a</span>) =&gt;</span> a.<span class="hljs-property">createdAt</span>);
+
+<span class="hljs-title function_">toSql</span>(popularActiveArticles, {});
+<span class="hljs-title function_">toSql</span>(recentActiveArticles, { <span class="hljs-attr">since</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>(<span class="hljs-string">&quot;2024-01-01&quot;</span>) });
+</code></pre>
+<h4 id="pattern-3%3A-repository-pattern" tabindex="-1"><a class="anchor" href="#pattern-3%3A-repository-pattern" aria-hidden="true">#</a> Pattern 3: Repository Pattern</h4>
+<pre class="hljs"><code><span class="hljs-keyword">class</span> <span class="hljs-title class_">UserRepository</span> {
+  <span class="hljs-keyword">private</span> baseQuery = <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>));
+
+  <span class="hljs-title function_">findActive</span>(<span class="hljs-params"></span>) {
+    <span class="hljs-keyword">return</span> <span class="hljs-variable language_">this</span>.<span class="hljs-property">baseQuery</span>.<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">isActive</span> === <span class="hljs-literal">true</span>);
+  }
+
+  <span class="hljs-title function_">findByDepartment</span>(<span class="hljs-params"><span class="hljs-attr">deptId</span>: <span class="hljs-built_in">number</span></span>) {
+    <span class="hljs-keyword">return</span> <span class="hljs-variable language_">this</span>.<span class="hljs-property">baseQuery</span>.<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span> === deptId);
+  }
+
+  <span class="hljs-title function_">findActiveInDepartment</span>(<span class="hljs-params"><span class="hljs-attr">deptId</span>: <span class="hljs-built_in">number</span></span>) {
+    <span class="hljs-keyword">return</span> <span class="hljs-variable language_">this</span>.<span class="hljs-title function_">findActive</span>().<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span> === deptId);
+  }
+}
+
+<span class="hljs-keyword">const</span> repo = <span class="hljs-keyword">new</span> <span class="hljs-title class_">UserRepository</span>();
+<span class="hljs-title function_">toSql</span>(repo.<span class="hljs-title function_">findActive</span>(), {});
+<span class="hljs-title function_">toSql</span>(repo.<span class="hljs-title function_">findActiveInDepartment</span>(<span class="hljs-number">5</span>), {});
+</code></pre>
+<p><strong>Key Takeaway</strong>: Query composition enables building reusable, composable query fragments that can be combined and specialized without duplication.</p>
 <hr>
 <p><a href="../README.md">← Back to README</a></p>
 
@@ -1827,6 +2096,13 @@ Full table updates are dangerous and must be explicitly allowed.
   <li class="toc-sub"><a href="#143-delete-statements">14.3 DELETE Statements</a></li>
   <li class="toc-sub"><a href="#144-safety-features">14.4 Safety Features</a></li>
   <li class="toc-sub"><a href="#145-executing-crud-operations">14.5 Executing CRUD Operations</a></li>
+  <li><a href="#15-query-composition-and-reusability">15. Query Composition and Reusability</a></li>
+  <li class="toc-sub"><a href="#151-chaining-operations-on-plans">15.1 Chaining Operations on Plans</a></li>
+  <li class="toc-sub"><a href="#152-immutability-and-base-queries">15.2 Immutability and Base Queries</a></li>
+  <li class="toc-sub"><a href="#153-branching-from-base-queries">15.3 Branching from Base Queries</a></li>
+  <li class="toc-sub"><a href="#154-parameter-accumulation">15.4 Parameter Accumulation</a></li>
+  <li class="toc-sub"><a href="#155-composition-with-all-operations">15.5 Composition with All Operations</a></li>
+  <li class="toc-sub"><a href="#156-practical-patterns">15.6 Practical Patterns</a></li>
 </ul>
 </nav>
     </div>

--- a/build/index.html
+++ b/build/index.html
@@ -70,7 +70,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
 </code></pre>
 <h2 id="quick-start" tabindex="-1"><a class="anchor" href="#quick-start" aria-hidden="true">#</a> Quick Start</h2>
 <h3 id="postgresql-example" tabindex="-1"><a class="anchor" href="#postgresql-example" aria-hidden="true">#</a> PostgreSQL Example</h3>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 <span class="hljs-keyword">import</span> pgPromise <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;pg-promise&quot;</span>;
 
@@ -89,20 +89,20 @@ npm install @webpods/tinqer-sql-better-sqlite3
 
 <span class="hljs-keyword">const</span> results = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
-  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 <span class="hljs-comment">// results: [{ id: 1, name: &quot;Alice&quot; }, { id: 2, name: &quot;Bob&quot; }]</span>
 </code></pre>
 <p><strong>The same query works with SQLite</strong> - just change the adapter and database connection:</p>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> <span class="hljs-title class_">Database</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;better-sqlite3&quot;</span>;
-<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-better-sqlite3&quot;</span>;
 
 <span class="hljs-comment">// Same schema definition</span>
@@ -121,13 +121,13 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <span class="hljs-comment">// Identical query logic</span>
 <span class="hljs-keyword">const</span> results = <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { minAge: <span class="hljs-built_in">number</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= params.<span class="hljs-property">minAge</span>)
       .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>)
       .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> })),
-  ),
   { <span class="hljs-attr">minAge</span>: <span class="hljs-number">18</span> },
 );
 <span class="hljs-comment">// results: [{ id: 1, name: &quot;Alice&quot; }, { id: 2, name: &quot;Bob&quot; }]</span>
@@ -204,6 +204,59 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <span class="hljs-comment">// The query builder returns a Queryable whose result type is inferred as</span>
 <span class="hljs-comment">// { id: number; name: string; email: string }</span>
 </code></pre>
+<h3 id="query-composition" tabindex="-1"><a class="anchor" href="#query-composition" aria-hidden="true">#</a> Query Composition</h3>
+<p>Query plans are <strong>immutable and composable</strong> - you can chain operations onto plan handles to create reusable base queries and branch into specialized variations.</p>
+<h4 id="chaining-operations-on-plans" tabindex="-1"><a class="anchor" href="#chaining-operations-on-plans" aria-hidden="true">#</a> Chaining Operations on Plans</h4>
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+
+<span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
+
+<span class="hljs-comment">// Start with base query</span>
+<span class="hljs-keyword">const</span> plan = <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>))
+  .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; <span class="hljs-number">18</span>)
+  .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">isActive</span>)
+  .<span class="hljs-title function_">orderBy</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">name</span>)
+  .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> ({ <span class="hljs-attr">id</span>: u.<span class="hljs-property">id</span>, <span class="hljs-attr">name</span>: u.<span class="hljs-property">name</span> }));
+
+<span class="hljs-keyword">const</span> { sql, params } = <span class="hljs-title function_">toSql</span>(plan, {});
+</code></pre>
+<h4 id="reusable-base-queries" tabindex="-1"><a class="anchor" href="#reusable-base-queries" aria-hidden="true">#</a> Reusable Base Queries</h4>
+<p>Plans are immutable - each operation returns a new plan without modifying the original. This enables creating base queries and branching:</p>
+<pre class="hljs"><code><span class="hljs-keyword">type</span> <span class="hljs-title class_">DeptParams</span> = { <span class="hljs-attr">dept</span>: <span class="hljs-built_in">number</span> };
+
+<span class="hljs-comment">// Reusable base query</span>
+<span class="hljs-keyword">const</span> usersInDept = <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">p</span>: <span class="hljs-title class_">DeptParams</span></span>) =&gt;</span>
+  q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">departmentId</span> === p.<span class="hljs-property">dept</span>),
+);
+
+<span class="hljs-comment">// Branch 1: Active users only</span>
+<span class="hljs-keyword">const</span> activeUsers = usersInDept
+  .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">isActive</span> === <span class="hljs-literal">true</span>)
+  .<span class="hljs-property">where</span>&lt;{ <span class="hljs-attr">minAge</span>: <span class="hljs-built_in">number</span> }&gt;(<span class="hljs-function">(<span class="hljs-params">u, p</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt;= p.<span class="hljs-property">minAge</span>);
+
+<span class="hljs-comment">// Branch 2: Inactive users only</span>
+<span class="hljs-keyword">const</span> inactiveUsers = usersInDept
+  .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">isActive</span> === <span class="hljs-literal">false</span>)
+  .<span class="hljs-property">where</span>&lt;{ <span class="hljs-attr">maxAge</span>: <span class="hljs-built_in">number</span> }&gt;(<span class="hljs-function">(<span class="hljs-params">u, p</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt;= p.<span class="hljs-property">maxAge</span>);
+
+<span class="hljs-comment">// Execute branches with different parameters</span>
+<span class="hljs-title function_">toSql</span>(activeUsers, { <span class="hljs-attr">dept</span>: <span class="hljs-number">1</span>, <span class="hljs-attr">minAge</span>: <span class="hljs-number">25</span> });
+<span class="hljs-title function_">toSql</span>(inactiveUsers, { <span class="hljs-attr">dept</span>: <span class="hljs-number">1</span>, <span class="hljs-attr">maxAge</span>: <span class="hljs-number">65</span> });
+</code></pre>
+<h4 id="parameter-accumulation" tabindex="-1"><a class="anchor" href="#parameter-accumulation" aria-hidden="true">#</a> Parameter Accumulation</h4>
+<p>Parameters from the builder function and chained operations are merged:</p>
+<pre class="hljs"><code><span class="hljs-keyword">type</span> <span class="hljs-title class_">BuilderParams</span> = { <span class="hljs-attr">baseAge</span>: <span class="hljs-built_in">number</span> };
+<span class="hljs-keyword">type</span> <span class="hljs-title class_">ChainParams</span> = { <span class="hljs-attr">maxAge</span>: <span class="hljs-built_in">number</span> };
+
+<span class="hljs-keyword">const</span> plan = <span class="hljs-title function_">defineSelect</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">p</span>: <span class="hljs-title class_">BuilderParams</span></span>) =&gt;</span>
+  q.<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">age</span> &gt; p.<span class="hljs-property">baseAge</span>),
+).<span class="hljs-property">where</span>&lt;<span class="hljs-title class_">ChainParams</span>&gt;(<span class="hljs-function">(<span class="hljs-params">u, p</span>) =&gt;</span> u.<span class="hljs-property">age</span> &lt; p.<span class="hljs-property">maxAge</span>);
+
+<span class="hljs-comment">// Must provide both parameter types</span>
+<span class="hljs-title function_">toSql</span>(plan, { <span class="hljs-attr">baseAge</span>: <span class="hljs-number">18</span>, <span class="hljs-attr">maxAge</span>: <span class="hljs-number">65</span> });
+</code></pre>
+<p>Composition works with all operations: <code>defineSelect</code>, <code>defineInsert</code>, <code>defineUpdate</code>, <code>defineDelete</code>.</p>
 <h3 id="joins" tabindex="-1"><a class="anchor" href="#joins" aria-hidden="true">#</a> Joins</h3>
 <p>Tinqer mirrors LINQ semantics. Inner joins have a dedicated operator; left outer and cross joins follow the familiar <code>groupJoin</code>/<code>selectMany</code> patterns from C#.</p>
 <h4 id="inner-join" tabindex="-1"><a class="anchor" href="#inner-join" aria-hidden="true">#</a> Inner Join</h4>
@@ -282,21 +335,19 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <pre class="hljs"><code><span class="hljs-comment">// Get top earner per department (automatically wrapped in subquery)</span>
 <span class="hljs-keyword">const</span> topEarners = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeSelect</span>(
   db,
-  <span class="hljs-title function_">defineSelect</span>(
-    schema,
-    <span class="hljs-function">(<span class="hljs-params">q, params, h</span>) =&gt;</span>
-      q
-        .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
-        .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
-          ...e,
-          <span class="hljs-attr">rank</span>: h
-            .<span class="hljs-title function_">window</span>(e)
-            .<span class="hljs-title function_">partitionBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">department</span>)
-            .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">salary</span>)
-            .<span class="hljs-title function_">rowNumber</span>(),
-        }))
-        .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> e.<span class="hljs-property">rank</span> === <span class="hljs-number">1</span>), <span class="hljs-comment">// Filtering on window function result</span>
-  ),
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, params, h</span>) =&gt;</span>
+    q
+      .<span class="hljs-title function_">from</span>(<span class="hljs-string">&quot;employees&quot;</span>)
+      .<span class="hljs-title function_">select</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> ({
+        ...e,
+        <span class="hljs-attr">rank</span>: h
+          .<span class="hljs-title function_">window</span>(e)
+          .<span class="hljs-title function_">partitionBy</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">department</span>)
+          .<span class="hljs-title function_">orderByDescending</span>(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.<span class="hljs-property">salary</span>)
+          .<span class="hljs-title function_">rowNumber</span>(),
+      }))
+      .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">e</span>) =&gt;</span> e.<span class="hljs-property">rank</span> === <span class="hljs-number">1</span>), <span class="hljs-comment">// Filtering on window function result</span>
   {},
 );
 
@@ -310,7 +361,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <p><strong>Automatic Subquery Wrapping</strong>: Tinqer automatically detects when <code>where()</code> clauses reference window function columns and wraps the query in a subquery, since SQL doesn’t allow filtering on window functions at the same level where they’re defined.</p>
 <p>See the <a href="docs/guide.md#8-window-functions">Window Functions Guide</a> for detailed examples of <code>RANK()</code>, <code>DENSE_RANK()</code>, complex ordering, and <a href="docs/guide.md#85-filtering-on-window-function-results">filtering on window results</a>.</p>
 <h3 id="crud-operations" tabindex="-1"><a class="anchor" href="#crud-operations" aria-hidden="true">#</a> CRUD Operations</h3>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert, defineUpdate, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
@@ -318,25 +369,25 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <span class="hljs-comment">// INSERT</span>
 <span class="hljs-keyword">const</span> insertedRows = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeInsert</span>(
   db,
-  <span class="hljs-title function_">defineInsert</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span>
     q.<span class="hljs-title function_">insertInto</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">values</span>({
       <span class="hljs-attr">name</span>: <span class="hljs-string">&quot;Alice&quot;</span>,
       <span class="hljs-attr">email</span>: <span class="hljs-string">&quot;alice@example.com&quot;</span>,
     }),
-  ),
   {},
 );
 
 <span class="hljs-comment">// UPDATE with RETURNING</span>
 <span class="hljs-keyword">const</span> inactiveUsers = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeUpdate</span>(
   db,
-  <span class="hljs-title function_">defineUpdate</span>(schema, <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoffDate: <span class="hljs-built_in">Date</span> }</span>) =&gt;</span>
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q, <span class="hljs-attr">params</span>: { cutoffDate: <span class="hljs-built_in">Date</span> }</span>) =&gt;</span>
     q
       .<span class="hljs-title function_">update</span>(<span class="hljs-string">&quot;users&quot;</span>)
       .<span class="hljs-title function_">set</span>({ <span class="hljs-attr">status</span>: <span class="hljs-string">&quot;inactive&quot;</span> })
       .<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">lastLogin</span> &lt; params.<span class="hljs-property">cutoffDate</span>)
       .<span class="hljs-title function_">returning</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">id</span>),
-  ),
   { <span class="hljs-attr">cutoffDate</span>: <span class="hljs-keyword">new</span> <span class="hljs-title class_">Date</span>(<span class="hljs-string">&quot;2023-01-01&quot;</span>) },
 );
 
@@ -345,7 +396,8 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <span class="hljs-comment">// DELETE</span>
 <span class="hljs-keyword">const</span> deletedCount = <span class="hljs-keyword">await</span> <span class="hljs-title function_">executeDelete</span>(
   db,
-  <span class="hljs-title function_">defineDelete</span>(schema, <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">status</span> === <span class="hljs-string">&quot;deleted&quot;</span>)),
+  schema,
+  <span class="hljs-function">(<span class="hljs-params">q</span>) =&gt;</span> q.<span class="hljs-title function_">deleteFrom</span>(<span class="hljs-string">&quot;users&quot;</span>).<span class="hljs-title function_">where</span>(<span class="hljs-function">(<span class="hljs-params">u</span>) =&gt;</span> u.<span class="hljs-property">status</span> === <span class="hljs-string">&quot;deleted&quot;</span>),
   {},
 );
 
@@ -477,6 +529,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
   <li class="toc-sub"><a href="#sql-generation-without-execution">SQL Generation Without Execution</a></li>
   <li><a href="#core-features">Core Features</a></li>
   <li class="toc-sub"><a href="#type-safe-query-building">Type-Safe Query Building</a></li>
+  <li class="toc-sub"><a href="#query-composition">Query Composition</a></li>
   <li class="toc-sub"><a href="#joins">Joins</a></li>
   <li class="toc-sub"><a href="#grouping-and-aggregation">Grouping and Aggregation</a></li>
   <li class="toc-sub"><a href="#window-functions">Window Functions</a></li>

--- a/build/llms.txt
+++ b/build/llms.txt
@@ -30,7 +30,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
 ### PostgreSQL Example
 
 ```typescript
-import { createSchema, defineSelect } from "@webpods/tinqer";
+import { createSchema } from "@webpods/tinqer";
 import { executeSelect } from "@webpods/tinqer-sql-pg-promise";
 import pgPromise from "pg-promise";
 
@@ -49,13 +49,13 @@ const schema = createSchema<Schema>();
 
 const results = await executeSelect(
   db,
-  defineSelect(schema, (q, params: { minAge: number }) =>
+  schema,
+  (q, params: { minAge: number }) =>
     q
       .from("users")
       .where((u) => u.age >= params.minAge)
       .orderBy((u) => u.name)
       .select((u) => ({ id: u.id, name: u.name })),
-  ),
   { minAge: 18 },
 );
 // results: [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }]
@@ -65,7 +65,7 @@ const results = await executeSelect(
 
 ```typescript
 import Database from "better-sqlite3";
-import { createSchema, defineSelect } from "@webpods/tinqer";
+import { createSchema } from "@webpods/tinqer";
 import { executeSelect } from "@webpods/tinqer-sql-better-sqlite3";
 
 // Same schema definition
@@ -84,13 +84,13 @@ const schema = createSchema<Schema>();
 // Identical query logic
 const results = executeSelect(
   db,
-  defineSelect(schema, (q, params: { minAge: number }) =>
+  schema,
+  (q, params: { minAge: number }) =>
     q
       .from("users")
       .where((u) => u.age >= params.minAge)
       .orderBy((u) => u.name)
       .select((u) => ({ id: u.id, name: u.name })),
-  ),
   { minAge: 18 },
 );
 // results: [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }]
@@ -175,6 +175,74 @@ const query = (q) =>
 // The query builder returns a Queryable whose result type is inferred as
 // { id: number; name: string; email: string }
 ```
+
+### Query Composition
+
+Query plans are **immutable and composable** - you can chain operations onto plan handles to create reusable base queries and branch into specialized variations.
+
+#### Chaining Operations on Plans
+
+```typescript
+import { defineSelect } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
+
+const schema = createSchema<Schema>();
+
+// Start with base query
+const plan = defineSelect(schema, (q) => q.from("users"))
+  .where((u) => u.age > 18)
+  .where((u) => u.isActive)
+  .orderBy((u) => u.name)
+  .select((u) => ({ id: u.id, name: u.name }));
+
+const { sql, params } = toSql(plan, {});
+```
+
+#### Reusable Base Queries
+
+Plans are immutable - each operation returns a new plan without modifying the original. This enables creating base queries and branching:
+
+```typescript
+type DeptParams = { dept: number };
+
+// Reusable base query
+const usersInDept = defineSelect(schema, (q, p: DeptParams) =>
+  q.from("users").where((u) => u.departmentId === p.dept),
+);
+
+// Branch 1: Active users only
+const activeUsers = usersInDept
+  .where((u) => u.isActive === true)
+  .where<{ minAge: number }>((u, p) => u.age >= p.minAge);
+
+// Branch 2: Inactive users only
+const inactiveUsers = usersInDept
+  .where((u) => u.isActive === false)
+  .where<{ maxAge: number }>((u, p) => u.age <= p.maxAge);
+
+// Execute branches with different parameters
+toSql(activeUsers, { dept: 1, minAge: 25 });
+toSql(inactiveUsers, { dept: 1, maxAge: 65 });
+```
+
+#### Parameter Accumulation
+
+Parameters from the builder function and chained operations are merged:
+
+```typescript
+type BuilderParams = { baseAge: number };
+type ChainParams = { maxAge: number };
+
+const plan = defineSelect(schema, (q, p: BuilderParams) =>
+  q.from("users").where((u) => u.age > p.baseAge),
+)
+.where<ChainParams>((u, p) => u.age < p.maxAge);
+
+// Must provide both parameter types
+toSql(plan, { baseAge: 18, maxAge: 65 });
+```
+
+Composition works with all operations: `defineSelect`, `defineInsert`, `defineUpdate`, `defineDelete`.
 
 ### Joins
 
@@ -272,21 +340,19 @@ Window functions enable calculations across rows related to the current row. Tin
 // Get top earner per department (automatically wrapped in subquery)
 const topEarners = await executeSelect(
   db,
-  defineSelect(
-    schema,
-    (q, params, h) =>
-      q
-        .from("employees")
-        .select((e) => ({
-          ...e,
-          rank: h
-            .window(e)
-            .partitionBy((r) => r.department)
-            .orderByDescending((r) => r.salary)
-            .rowNumber(),
-        }))
-        .where((e) => e.rank === 1), // Filtering on window function result
-  ),
+  schema,
+  (q, params, h) =>
+    q
+      .from("employees")
+      .select((e) => ({
+        ...e,
+        rank: h
+          .window(e)
+          .partitionBy((r) => r.department)
+          .orderByDescending((r) => r.salary)
+          .rowNumber(),
+      }))
+      .where((e) => e.rank === 1), // Filtering on window function result
   {},
 );
 
@@ -305,7 +371,7 @@ See the [Window Functions Guide](docs/guide.md#8-window-functions) for detailed 
 ### CRUD Operations
 
 ```typescript
-import { createSchema, defineInsert, defineUpdate, defineDelete } from "@webpods/tinqer";
+import { createSchema } from "@webpods/tinqer";
 import { executeInsert, executeUpdate, executeDelete } from "@webpods/tinqer-sql-pg-promise";
 
 const schema = createSchema<Schema>();
@@ -313,25 +379,25 @@ const schema = createSchema<Schema>();
 // INSERT
 const insertedRows = await executeInsert(
   db,
-  defineInsert(schema, (q) =>
+  schema,
+  (q) =>
     q.insertInto("users").values({
       name: "Alice",
       email: "alice@example.com",
     }),
-  ),
   {},
 );
 
 // UPDATE with RETURNING
 const inactiveUsers = await executeUpdate(
   db,
-  defineUpdate(schema, (q, params: { cutoffDate: Date }) =>
+  schema,
+  (q, params: { cutoffDate: Date }) =>
     q
       .update("users")
       .set({ status: "inactive" })
       .where((u) => u.lastLogin < params.cutoffDate)
       .returning((u) => u.id),
-  ),
   { cutoffDate: new Date("2023-01-01") },
 );
 
@@ -340,7 +406,8 @@ const inactiveUsers = await executeUpdate(
 // DELETE
 const deletedCount = await executeDelete(
   db,
-  defineDelete(schema, (q) => q.deleteFrom("users").where((u) => u.status === "deleted")),
+  schema,
+  (q) => q.deleteFrom("users").where((u) => u.status === "deleted"),
   {},
 );
 
@@ -502,13 +569,7 @@ npm install @webpods/tinqer-sql-pg-promise pg-promise
 
 ```typescript
 import pgPromise from "pg-promise";
-import {
-  createSchema,
-  defineSelect,
-  defineInsert,
-  defineUpdate,
-  defineDelete,
-} from "@webpods/tinqer";
+import { createSchema, defineSelect } from "@webpods/tinqer";
 import {
   executeSelect,
   executeInsert,
@@ -528,55 +589,56 @@ const schema = createSchema<Schema>();
 // Execute with params
 const activeUsers = await executeSelect(
   db,
-  defineSelect(schema, (q, params: { minAge: number }) =>
+  schema,
+  (q, params: { minAge: number }) =>
     q
       .from("users")
       .where((u) => u.active && u.age >= params.minAge)
       .orderBy((u) => u.name),
-  ),
   { minAge: 18 },
 );
 
 // Execute with params
 const matchingUsers = await executeSelect(
   db,
-  defineSelect(schema, (q, params: { minAge: number }) =>
+  schema,
+  (q, params: { minAge: number }) =>
     q
       .from("users")
       .where((u) => u.age >= params.minAge)
       .select((u) => ({ id: u.id, name: u.name })),
-  ),
   { minAge: 21 },
 );
 
 // INSERT with RETURNING
 const createdUsers = await executeInsert(
   db,
-  defineInsert(schema, (q) =>
+  schema,
+  (q) =>
     q
       .insertInto("users")
       .values({ name: "Alice", email: "alice@example.com", age: 30, active: true })
       .returning((u) => ({ id: u.id, createdAt: u.createdAt })),
-  ),
   {},
 );
 
 // UPDATE
 const updatedCount = await executeUpdate(
   db,
-  defineUpdate(schema, (q) =>
+  schema,
+  (q) =>
     q
       .update("users")
       .set({ active: false })
       .where((u) => u.age > 65),
-  ),
   {},
 );
 
 // DELETE
 const deletedCount = await executeDelete(
   db,
-  defineDelete(schema, (q) => q.deleteFrom("users").where((u) => !u.active)),
+  schema,
+  (q) => q.deleteFrom("users").where((u) => !u.active),
   {},
 );
 
@@ -609,13 +671,7 @@ npm install @webpods/tinqer-sql-better-sqlite3 better-sqlite3
 
 ```typescript
 import Database from "better-sqlite3";
-import {
-  createSchema,
-  defineSelect,
-  defineInsert,
-  defineUpdate,
-  defineDelete,
-} from "@webpods/tinqer";
+import { createSchema, defineSelect } from "@webpods/tinqer";
 import {
   executeSelect,
   executeInsert,
@@ -643,40 +699,38 @@ db.exec(`
 
 const inserted = executeInsert(
   db,
-  defineInsert(schema, (q) =>
-    q.insertInto("users").values({ name: "Sam", email: "sam@example.com", age: 28 }),
-  ),
+  schema,
+  (q) => q.insertInto("users").values({ name: "Sam", email: "sam@example.com", age: 28 }),
   {},
 );
 // inserted === 1
 
 const users = executeSelect(
   db,
-  defineSelect(schema, (q, params: { active: number }) =>
+  schema,
+  (q, params: { active: number }) =>
     q
       .from("users")
       .where((u) => u.isActive === params.active)
       .orderBy((u) => u.name),
-  ),
   { active: 1 },
 );
 
 const updated = executeUpdate(
   db,
-  defineUpdate(schema, (q) =>
+  schema,
+  (q) =>
     q
       .update("users")
       .set({ isActive: 0 })
       .where((u) => u.age > 60),
-  ),
   {},
 );
 
 const removed = executeDelete(
   db,
-  defineDelete(schema, (q, params: { cutoff: number }) =>
-    q.deleteFrom("users").where((u) => u.age < params.cutoff),
-  ),
+  schema,
+  (q, params: { cutoff: number }) => q.deleteFrom("users").where((u) => u.age < params.cutoff),
   { cutoff: 18 },
 );
 
@@ -840,7 +894,7 @@ const { sql, params } = toSql(
 **Example - Execution**
 
 ```typescript
-import { createSchema, defineSelect } from "@webpods/tinqer";
+import { createSchema } from "@webpods/tinqer";
 import { executeSelect } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
@@ -851,12 +905,12 @@ const schema = createSchema<Schema>();
 
 const users = await executeSelect(
   db,
-  defineSelect(schema, (q, params: { minAge: number }) =>
+  schema,
+  (q, params: { minAge: number }) =>
     q
       .from("users")
       .where((u) => u.age >= params.minAge)
       .orderBy((u) => u.name),
-  ),
   { minAge: 21 },
 );
 // Returns: Array of user objects
@@ -920,7 +974,7 @@ const { sql, params } = toSql(
 **Example - Execution**
 
 ```typescript
-import { createSchema, defineInsert } from "@webpods/tinqer";
+import { createSchema } from "@webpods/tinqer";
 import { executeInsert } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
@@ -932,21 +986,20 @@ const schema = createSchema<Schema>();
 // Without RETURNING - returns number of rows inserted
 const rowCount = await executeInsert(
   db,
-  defineInsert(schema, (q, params: { name: string }) =>
-    q.insertInto("users").values({ name: params.name }),
-  ),
+  schema,
+  (q, params: { name: string }) => q.insertInto("users").values({ name: params.name }),
   { name: "Alice" },
 );
 
 // With RETURNING - returns inserted rows
 const createdUsers = await executeInsert(
   db,
-  defineInsert(schema, (q, params: { name: string }) =>
+  schema,
+  (q, params: { name: string }) =>
     q
       .insertInto("users")
       .values({ name: params.name })
       .returning((u) => ({ id: u.id, name: u.name })),
-  ),
   { name: "Bob" },
 );
 ```
@@ -1015,7 +1068,7 @@ const { sql, params } = toSql(
 **Example - Execution**
 
 ```typescript
-import { createSchema, defineUpdate } from "@webpods/tinqer";
+import { createSchema } from "@webpods/tinqer";
 import { executeUpdate } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
@@ -1027,25 +1080,25 @@ const schema = createSchema<Schema>();
 // Without RETURNING - returns number of rows updated
 const updatedRows = await executeUpdate(
   db,
-  defineUpdate(schema, (q, params: { cutoff: Date }) =>
+  schema,
+  (q, params: { cutoff: Date }) =>
     q
       .update("users")
       .set({ status: "inactive" })
       .where((u) => u.lastLogin < params.cutoff),
-  ),
   { cutoff: new Date("2024-01-01") },
 );
 
 // With RETURNING - returns updated rows
 const updatedUsers = await executeUpdate(
   db,
-  defineUpdate(schema, (q, params: { cutoff: Date }) =>
+  schema,
+  (q, params: { cutoff: Date }) =>
     q
       .update("users")
       .set({ status: "inactive" })
       .where((u) => u.lastLogin < params.cutoff)
       .returning((u) => ({ id: u.id, status: u.status })),
-  ),
   { cutoff: new Date("2024-01-01") },
 );
 ```
@@ -1108,7 +1161,7 @@ const { sql, params } = toSql(
 **Example - Execution**
 
 ```typescript
-import { createSchema, defineDelete } from "@webpods/tinqer";
+import { createSchema } from "@webpods/tinqer";
 import { executeDelete } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
@@ -1119,9 +1172,8 @@ const schema = createSchema<Schema>();
 
 const deletedCount = await executeDelete(
   db,
-  defineDelete(schema, (q, params: { status: string }) =>
-    q.deleteFrom("users").where((u) => u.status === params.status),
-  ),
+  schema,
+  (q, params: { status: string }) => q.deleteFrom("users").where((u) => u.status === params.status),
   { status: "inactive" },
 );
 ```
@@ -1153,7 +1205,7 @@ Use `onSql` for logging, testing, or debugging without changing execution flow.
 Creates a phantom-typed `DatabaseSchema` that ties table names to row types. The schema is passed to execution functions, which provide a type-safe query builder through the lambda's first parameter.
 
 ```typescript
-import { createSchema, defineSelect } from "@webpods/tinqer";
+import { createSchema } from "@webpods/tinqer";
 import { executeSelect } from "@webpods/tinqer-sql-pg-promise";
 
 interface Schema {
@@ -1163,10 +1215,11 @@ interface Schema {
 
 const schema = createSchema<Schema>();
 
-// Schema is passed to defineSelect, which provides the query builder 'q' parameter
+// Schema is passed to executeSelect, which provides the query builder 'q' parameter
 const results = await executeSelect(
   db,
-  defineSelect(schema, (q) => q.from("users").where((u) => u.email.endsWith("@example.com"))),
+  schema,
+  (q) => q.from("users").where((u) => u.email.endsWith("@example.com")),
   {},
 );
 ```
@@ -1425,7 +1478,7 @@ describe("SQL Generation", () => {
 ```typescript
 import { describe, it, beforeEach } from "mocha";
 import { strict as assert } from "assert";
-import { createSchema, defineSelect } from "@webpods/tinqer";
+import { createSchema } from "@webpods/tinqer";
 import { executeSelect } from "@webpods/tinqer-sql-pg-promise";
 import { db } from "./shared-db.js";
 
@@ -1440,12 +1493,12 @@ describe("PostgreSQL Integration", () => {
   it("should execute SELECT query", async () => {
     const results = await executeSelect(
       db,
-      defineSelect(schema, (q, params: { minAge: number }) =>
+      schema,
+      (q, params: { minAge: number }) =>
         q
           .from("users")
           .where((u) => u.age >= params.minAge)
           .select((u) => u.name),
-      ),
       { minAge: 25 },
     );
 
@@ -1693,12 +1746,12 @@ Error: Unsupported AST node type: TemplateLiteral
 // Incorrect - template literal in lambda
 .where(u => u.name === `User ${userId}`)
 
-// Correct - use params with defineSelect and executeSelect
+// Correct - use params with executeSelect
 await executeSelect(
   db,
-  defineSelect(schema, (q, params: { name: string }) =>
+  schema,
+  (q, params: { name: string }) =>
     q.from("users").where((u) => u.name === params.name),
-  ),
   { name: `User ${userId}` },
 );
 ```
@@ -1716,12 +1769,12 @@ Error: Unknown identifier 'externalVar'
 const minAge = 18;
 .where(u => u.age >= minAge)
 
-// Correct - params pattern with defineSelect and executeSelect
+// Correct - params pattern with executeSelect
 await executeSelect(
   db,
-  defineSelect(schema, (q, params: { minAge: number }) =>
+  schema,
+  (q, params: { minAge: number }) =>
     q.from("users").where((u) => u.age >= params.minAge),
-  ),
   { minAge: 18 },
 );
 ```
@@ -1737,7 +1790,8 @@ const schema = createSchema(); // No schema type provided
 // Types will be 'unknown' without schema
 const result = await executeSelect(
   db,
-  defineSelect(schema, (q) => q.from("users")), // Type is Queryable<unknown>
+  schema,
+  (q) => q.from("users"), // Type is Queryable<unknown>
   {},
 );
 ```
@@ -1754,7 +1808,8 @@ const schema = createSchema<Schema>();
 // Now fully typed from schema
 const result = await executeSelect(
   db,
-  defineSelect(schema, (q) => q.from("users")), // Fully typed: Queryable<{ id: number; name: string }>
+  schema,
+  (q) => q.from("users"), // Fully typed: Queryable<{ id: number; name: string }>
   {},
 );
 ```
@@ -1867,6 +1922,13 @@ Complete reference for all query operations, parameters, and CRUD functionality 
   - [14.3 DELETE Statements](#143-delete-statements)
   - [14.4 Safety Features](#144-safety-features)
   - [14.5 Executing CRUD Operations](#145-executing-crud-operations)
+- [15. Query Composition and Reusability](#15-query-composition-and-reusability)
+  - [15.1 Chaining Operations on Plans](#151-chaining-operations-on-plans)
+  - [15.2 Immutability and Base Queries](#152-immutability-and-base-queries)
+  - [15.3 Branching from Base Queries](#153-branching-from-base-queries)
+  - [15.4 Parameter Accumulation](#154-parameter-accumulation)
+  - [15.5 Composition with All Operations](#155-composition-with-all-operations)
+  - [15.6 Practical Patterns](#156-practical-patterns)
 
 ---
 
@@ -2620,13 +2682,13 @@ ORDER BY "totalSalary" DESC
 ```typescript
 const largeDepartments = await executeSelect(
   db,
-  defineSelect(schema, (q) =>
+  schema,
+  (q) =>
     q
       .from("users")
       .groupBy((u) => u.departmentId)
       .select((g) => ({ departmentId: g.key, headcount: g.count() }))
       .where((row) => row.headcount > 5),
-  ),
   {},
 );
 ```
@@ -2986,7 +3048,8 @@ Get the top earner from each department:
 ```typescript
 const topEarners = await executeSelect(
   db,
-  defineSelect(schema, (q, params, helpers) =>
+  schema,
+  (q, params, helpers) =>
     q
       .from("employees")
       .select((e) => ({
@@ -2999,7 +3062,6 @@ const topEarners = await executeSelect(
       }))
       .where((r) => r.rank === 1)
       .orderBy((r) => r.department),
-  ),
   {},
 );
 ```
@@ -3036,7 +3098,8 @@ const schema = createSchema<EmployeeDeptSchema>();
 
 const top3Engineering = await executeSelect(
   db,
-  defineSelect(schema, (q, params: { deptId: number }, helpers) =>
+  schema,
+  (q, params: { deptId: number }, helpers) =>
     q
       .from("employees")
       .select((e) => ({
@@ -3050,7 +3113,6 @@ const top3Engineering = await executeSelect(
       }))
       .where((r) => r.rank <= 3 && r.department_id === params.deptId)
       .orderBy((r) => r.rank),
-  ),
   { deptId: 1 },
 );
 ```
@@ -3078,7 +3140,8 @@ const schema = createSchema<PerformanceSchema>();
 
 const topPerformers = await executeSelect(
   db,
-  defineSelect(schema, (q, params, helpers) =>
+  schema,
+  (q, params, helpers) =>
     q
       .from("employees")
       .select((e) => ({
@@ -3089,7 +3152,6 @@ const topPerformers = await executeSelect(
           .rowNumber(),
       }))
       .where((r) => r.performance_rank <= 10),
-  ),
   {},
 );
 ```
@@ -3115,7 +3177,8 @@ const schema = createSchema<ActiveEmployeeSchema>();
 
 const activeTopEarners = await executeSelect(
   db,
-  defineSelect(schema, (q, params, helpers) =>
+  schema,
+  (q, params, helpers) =>
     q
       .from("employees")
       .select((e) => ({
@@ -3132,7 +3195,6 @@ const activeTopEarners = await executeSelect(
       .where((r) => r.dept_rank <= 2 && r.is_active === true)
       .orderBy((r) => r.department)
       .thenBy((r) => r.dept_rank),
-  ),
   {},
 );
 ```
@@ -3294,12 +3356,12 @@ Queries are executed directly without requiring a materialization method. The qu
 ```typescript
 const activeUsers = await executeSelect(
   db,
-  defineSelect(schema, (q) =>
+  schema,
+  (q) =>
     q
       .from("users")
       .where((u) => u.active)
       .orderBy((u) => u.name),
-  ),
   {},
 );
 ```
@@ -3813,7 +3875,7 @@ The adapter packages provide execution functions for all CRUD operations:
 #### PostgreSQL (pg-promise)
 
 ```typescript
-import { createSchema, defineInsert, defineUpdate, defineDelete } from "@webpods/tinqer";
+import { createSchema } from "@webpods/tinqer";
 import { executeInsert, executeUpdate, executeDelete } from "@webpods/tinqer-sql-pg-promise";
 
 const schema = createSchema<Schema>();
@@ -3821,12 +3883,12 @@ const schema = createSchema<Schema>();
 // Execute INSERT with RETURNING
 const insertedUsers = await executeInsert(
   db,
-  defineInsert(schema, (q) =>
+  schema,
+  (q) =>
     q
       .insertInto("users")
       .values({ name: "Frank", age: 28 })
       .returning((u) => ({ id: u.id, name: u.name })),
-  ),
   {},
 );
 // Returns: [{ id: 123, name: "Frank" }]
@@ -3834,12 +3896,12 @@ const insertedUsers = await executeInsert(
 // Execute UPDATE - returns affected row count
 const updateCount = await executeUpdate(
   db,
-  defineUpdate(schema, (q) =>
+  schema,
+  (q) =>
     q
       .update("users")
       .set({ age: 29 })
       .where((u) => u.id === 123),
-  ),
   {},
 );
 // Returns number of affected rows
@@ -3847,7 +3909,8 @@ const updateCount = await executeUpdate(
 // Execute DELETE - returns affected row count
 const deleteCount = await executeDelete(
   db,
-  defineDelete(schema, (q) => q.deleteFrom("users").where((u) => u.id === 123)),
+  schema,
+  (q) => q.deleteFrom("users").where((u) => u.id === 123),
   {},
 );
 ```
@@ -3855,7 +3918,7 @@ const deleteCount = await executeDelete(
 #### SQLite (better-sqlite3)
 
 ```typescript
-import { createSchema, defineInsert, defineUpdate, defineDelete } from "@webpods/tinqer";
+import { createSchema } from "@webpods/tinqer";
 import { executeInsert, executeUpdate, executeDelete } from "@webpods/tinqer-sql-better-sqlite3";
 
 const schema = createSchema<Schema>();
@@ -3863,7 +3926,8 @@ const schema = createSchema<Schema>();
 // Execute INSERT - returns row count
 const insertCount = executeInsert(
   db,
-  defineInsert(schema, (q) => q.insertInto("users").values({ name: "Grace", age: 30 })),
+  schema,
+  (q) => q.insertInto("users").values({ name: "Grace", age: 30 }),
   {},
 );
 // Returns number of inserted rows
@@ -3871,24 +3935,25 @@ const insertCount = executeInsert(
 // Execute UPDATE - returns row count
 const updateCount = executeUpdate(
   db,
-  defineUpdate(schema, (q) =>
+  schema,
+  (q) =>
     q
       .update("users")
       .set({ age: 33 })
       .where((u) => u.name === "Henry"),
-  ),
   {},
 );
 
 // Execute DELETE - returns row count
 const deleteCount = executeDelete(
   db,
-  defineDelete(schema, (q) => q.deleteFrom("users").where((u) => u.age > 100)),
+  schema,
+  (q) => q.deleteFrom("users").where((u) => u.age > 100),
   {},
 );
 ```
 
-SQLite helpers always return the number of affected rows. To inspect row data after an insert or update, run a follow-up SELECT query using `defineSelect` and `executeSelect`.
+SQLite helpers always return the number of affected rows. To inspect row data after an insert or update, run a follow-up SELECT query using `executeSelect`.
 
 #### Transaction Support
 
@@ -3905,47 +3970,350 @@ const schema = createSchema<TxSchema>();
 await db.tx(async (t) => {
   const users = await executeInsert(
     t,
-    defineInsert(schema, (q) =>
+    schema,
+    (q) =>
       q
         .insertInto("users")
         .values({ name: "Ivy" })
         .returning((u) => u.id),
-    ),
     {},
   );
 
   await executeInsert(
     t,
-    defineInsert(schema, (q) =>
+    schema,
+    (q) =>
       q.insertInto("user_logs").values({
         userId: users[0]!.id,
         action: "created",
       }),
-    ),
     {},
   );
 });
 
 // SQLite transactions
 const transaction = sqliteDb.transaction(() => {
-  executeInsert(
-    db,
-    defineInsert(schema, (q) => q.insertInto("users").values({ name: "Jack" })),
-    {},
-  );
+  executeInsert(db, schema, (q) => q.insertInto("users").values({ name: "Jack" }), {});
   executeUpdate(
     db,
-    defineUpdate(schema, (q) =>
+    schema,
+    (q) =>
       q
         .update("users")
         .set({ lastLogin: new Date() })
         .where((u) => u.name === "Jack"),
-    ),
     {},
   );
 });
 transaction();
 ```
+
+---
+
+## 15. Query Composition and Reusability
+
+Tinqer query plans are **immutable and composable**. Plan handles returned by `define*` functions support method chaining - each operation returns a new plan without modifying the original. This enables powerful query composition patterns: reusable base queries, branching specialized variations, and parameter accumulation.
+
+### 15.1 Chaining Operations on Plans
+
+All plan handles support chaining operations like `where()`, `orderBy()`, `select()`, etc.:
+
+```typescript
+import { createSchema, defineSelect } from "@webpods/tinqer";
+import { toSql } from "@webpods/tinqer-sql-pg-promise";
+
+interface Schema {
+  users: { id: number; name: string; age: number; isActive: boolean };
+}
+
+const schema = createSchema<Schema>();
+
+// Chain operations on the plan handle
+const plan = defineSelect(schema, (q) => q.from("users"))
+  .where((u) => u.age > 18)
+  .where((u) => u.isActive === true)
+  .orderBy((u) => u.name)
+  .select((u) => ({ id: u.id, name: u.name }));
+
+const { sql, params } = toSql(plan, {});
+// SELECT "id" AS "id", "name" AS "name" FROM "users"
+// WHERE "age" > $(__p1) AND "isActive" = $(__p2)
+// ORDER BY "name" ASC
+```
+
+### 15.2 Immutability and Base Queries
+
+Plans are immutable - calling a method returns a **new plan** without modifying the original:
+
+```typescript
+const basePlan = defineSelect(schema, (q) => q.from("users"));
+
+const withAge = basePlan.where((u) => u.age > 18);
+const withStatus = basePlan.where((u) => u.isActive === true);
+
+// basePlan is unchanged
+// withAge and withStatus are independent plans
+```
+
+This immutability enables creating **reusable base queries**:
+
+```typescript
+interface Schema {
+  orders: {
+    id: number;
+    userId: number;
+    total: number;
+    status: string;
+    createdAt: Date;
+  };
+}
+
+const schema = createSchema<Schema>();
+
+// Reusable base query
+type UserOrdersParams = { userId: number };
+
+const userOrders = defineSelect(schema, (q, p: UserOrdersParams) =>
+  q
+    .from("orders")
+    .where((o) => o.userId === p.userId)
+    .orderBy((o) => o.createdAt),
+);
+
+// Use the base query in different contexts
+const recentUserOrders = userOrders.take(10);
+const highValueUserOrders = userOrders.where((o) => o.total > 1000);
+
+// Execute with parameters
+toSql(recentUserOrders, { userId: 42 });
+toSql(highValueUserOrders, { userId: 42 });
+```
+
+### 15.3 Branching from Base Queries
+
+Since plans are immutable, you can branch multiple specialized queries from a single base:
+
+```typescript
+interface Schema {
+  users: {
+    id: number;
+    name: string;
+    age: number;
+    isActive: boolean;
+    departmentId: number;
+  };
+}
+
+const schema = createSchema<Schema>();
+
+type DeptParams = { departmentId: number };
+
+// Base query: users in a department
+const usersInDept = defineSelect(schema, (q, p: DeptParams) =>
+  q.from("users").where((u) => u.departmentId === p.departmentId),
+);
+
+// Branch 1: Active users only
+const activeUsersInDept = usersInDept
+  .where((u) => u.isActive === true)
+  .where<{ minAge: number }>((u, p) => u.age >= p.minAge)
+  .orderBy((u) => u.name);
+
+// Branch 2: Inactive users only
+const inactiveUsersInDept = usersInDept
+  .where((u) => u.isActive === false)
+  .where<{ maxAge: number }>((u, p) => u.age <= p.maxAge)
+  .orderBy((u) => u.age);
+
+// Branch 3: Senior staff
+const seniorStaffInDept = usersInDept
+  .where((u) => u.age >= 50)
+  .select((u) => ({ id: u.id, name: u.name, age: u.age }));
+
+// Execute branches with different parameters
+toSql(activeUsersInDept, { departmentId: 1, minAge: 25 });
+toSql(inactiveUsersInDept, { departmentId: 1, maxAge: 65 });
+toSql(seniorStaffInDept, { departmentId: 1 });
+```
+
+### 15.4 Parameter Accumulation
+
+Parameters from the builder function and chained operations are **merged automatically**:
+
+```typescript
+interface Schema {
+  products: {
+    id: number;
+    name: string;
+    price: number;
+    category: string;
+    inStock: boolean;
+  };
+}
+
+const schema = createSchema<Schema>();
+
+// Builder function defines initial params
+type BuilderParams = { category: string };
+
+const plan = defineSelect(schema, (q, p: BuilderParams) =>
+  q.from("products").where((prod) => prod.category === p.category),
+);
+
+// Chained operations add more params
+type ChainParams1 = { minPrice: number };
+type ChainParams2 = { maxPrice: number };
+
+const refinedPlan = plan
+  .where<ChainParams1>((prod, p) => prod.price >= p.minPrice)
+  .where<ChainParams2>((prod, p) => prod.price <= p.maxPrice)
+  .where((prod) => prod.inStock === true);
+
+// Must provide ALL accumulated parameters
+const { sql, params } = toSql(refinedPlan, {
+  category: "electronics",
+  minPrice: 100,
+  maxPrice: 1000,
+});
+
+// params contains: { category, minPrice, maxPrice, __p1: true }
+```
+
+**Type safety**: TypeScript enforces that all accumulated parameters are provided at execution time.
+
+### 15.5 Composition with All Operations
+
+Composition works with all CRUD operations, not just SELECT:
+
+#### INSERT Composition
+
+```typescript
+interface Schema {
+  posts: {
+    id: number;
+    userId: number;
+    title: string;
+    content: string;
+    isPublished: boolean;
+  };
+}
+
+const schema = createSchema<Schema>();
+
+const insertPost = defineInsert(schema, (q) => q.insertInto("posts"))
+  .values({
+    userId: 1,
+    title: "My Post",
+    content: "Post content",
+    isPublished: false,
+  })
+  .returning((p) => ({ id: p.id, title: p.title }));
+
+toSql(insertPost, {});
+```
+
+#### UPDATE Composition
+
+```typescript
+const updatePlan = defineUpdate(schema, (q) => q.update("posts"))
+  .set({ isPublished: true })
+  .where<{ minViews: number }>((p, params) => p.viewCount > params.minViews)
+  .returning((p) => p.id);
+
+toSql(updatePlan, { minViews: 1000 });
+```
+
+#### DELETE Composition
+
+```typescript
+const deletePlan = defineDelete(schema, (q) => q.deleteFrom("posts"))
+  .where((p) => p.isPublished === false)
+  .where<{ beforeDate: Date }>((p, params) => p.createdAt < params.beforeDate);
+
+toSql(deletePlan, { beforeDate: new Date("2024-01-01") });
+```
+
+### 15.6 Practical Patterns
+
+#### Pattern 1: Pagination Helper
+
+```typescript
+interface Schema {
+  articles: {
+    id: number;
+    title: string;
+    createdAt: Date;
+    viewCount: number;
+  };
+}
+
+const schema = createSchema<Schema>();
+
+type PageParams = { page: number; pageSize: number };
+
+function paginate<TPlan extends { skip: Function; take: Function }>(
+  plan: TPlan,
+  page: number,
+  pageSize: number,
+): TPlan {
+  return plan.skip((page - 1) * pageSize).take(pageSize) as TPlan;
+}
+
+const allArticles = defineSelect(schema, (q) =>
+  q.from("articles").orderBy((a) => a.createdAt),
+);
+
+// Page 1
+const page1 = paginate(allArticles, 1, 20);
+toSql(page1, {});
+
+// Page 2
+const page2 = paginate(allArticles, 2, 20);
+toSql(page2, {});
+```
+
+#### Pattern 2: Common Filters
+
+```typescript
+const activeArticles = defineSelect(schema, (q) =>
+  q.from("articles").where((a) => a.isActive === true),
+);
+
+const popularActiveArticles = activeArticles.where((a) => a.viewCount > 1000);
+
+const recentActiveArticles = activeArticles
+  .where<{ since: Date }>((a, p) => a.createdAt >= p.since)
+  .orderBy((a) => a.createdAt);
+
+toSql(popularActiveArticles, {});
+toSql(recentActiveArticles, { since: new Date("2024-01-01") });
+```
+
+#### Pattern 3: Repository Pattern
+
+```typescript
+class UserRepository {
+  private baseQuery = defineSelect(schema, (q) => q.from("users"));
+
+  findActive() {
+    return this.baseQuery.where((u) => u.isActive === true);
+  }
+
+  findByDepartment(deptId: number) {
+    return this.baseQuery.where((u) => u.departmentId === deptId);
+  }
+
+  findActiveInDepartment(deptId: number) {
+    return this.findActive().where((u) => u.departmentId === deptId);
+  }
+}
+
+const repo = new UserRepository();
+toSql(repo.findActive(), {});
+toSql(repo.findActiveInDepartment(5), {});
+```
+
+**Key Takeaway**: Query composition enables building reusable, composable query fragments that can be combined and specialized without duplication.
 
 ---
 


### PR DESCRIPTION
Regenerated all HTML documentation from tinqer repository updates:

Changes from tinqer 0.0.21:
- Fixed execute* API pattern across all documentation (38 instances)
- Removed incorrect defineSelect/Insert/Update/Delete nesting in examples
- Cleaned up unnecessary imports in execution examples
- Added comprehensive Query Composition documentation
  - New section in README/index with chaining, reusable queries, parameter accumulation
  - New Section 15 in guide with 6 subsections covering composition patterns
  - Examples: branching queries, pagination helper, repository pattern

Files updated:
- build/index.html (README content)
- build/guide.html (comprehensive composition section added)
- build/api-reference.html (cleaned imports)
- build/adapters.html (cleaned imports)
- build/development.html (cleaned imports)
- build/llms.txt (107,073 bytes, up from previous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)