### PR TITLE
docs: regenerate site with updated package names and version 0.0.22

### DIFF
--- a/build/adapters.html
+++ b/build/adapters.html
@@ -57,7 +57,7 @@
       <article class="markdown-body">
         <p><a href="../README.md">← Back to README</a></p>
 <h1 id="database-adapters" tabindex="-1"><a class="anchor" href="#database-adapters" aria-hidden="true">#</a> Database Adapters</h1>
-<p>Tinqer ships dedicated adapters for PostgreSQL (<code>@webpods/tinqer-sql-pg-promise</code>) and SQLite (<code>@webpods/tinqer-sql-better-sqlite3</code>). Both share the same builder APIs while handling dialect-specific SQL generation and parameter formatting.</p>
+<p>Tinqer ships dedicated adapters for PostgreSQL (<code>@tinqerjs/pg-promise-adapter</code>) and SQLite (<code>@tinqerjs/better-sqlite3-adapter</code>). Both share the same builder APIs while handling dialect-specific SQL generation and parameter formatting.</p>
 <h2 id="table-of-contents" tabindex="-1"><a class="anchor" href="#table-of-contents" aria-hidden="true">#</a> Table of Contents</h2>
 <ul>
 <li><a href="#1-postgresql-adapter">1. PostgreSQL Adapter</a>
@@ -86,18 +86,18 @@
 <hr>
 <h2 id="1-postgresql-adapter" tabindex="-1"><a class="anchor" href="#1-postgresql-adapter" aria-hidden="true">#</a> 1. PostgreSQL Adapter</h2>
 <h3 id="11-installation" tabindex="-1"><a class="anchor" href="#11-installation" aria-hidden="true">#</a> 1.1 Installation</h3>
-<pre class="hljs"><code>npm install @webpods/tinqer-sql-pg-promise pg-promise
+<pre class="hljs"><code>npm install @tinqerjs/pg-promise-adapter pg-promise
 </code></pre>
 <h3 id="12-setup-%26-query-execution" tabindex="-1"><a class="anchor" href="#12-setup-%26-query-execution" aria-hidden="true">#</a> 1.2 Setup &amp; Query Execution</h3>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> pgPromise <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;pg-promise&quot;</span>;
-<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> {
   executeSelect,
   executeInsert,
   executeUpdate,
   executeDelete,
   toSql,
-} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">email</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">active</span>: <span class="hljs-built_in">boolean</span> };
@@ -180,18 +180,18 @@
 <hr>
 <h2 id="2-sqlite-adapter" tabindex="-1"><a class="anchor" href="#2-sqlite-adapter" aria-hidden="true">#</a> 2. SQLite Adapter</h2>
 <h3 id="21-installation" tabindex="-1"><a class="anchor" href="#21-installation" aria-hidden="true">#</a> 2.1 Installation</h3>
-<pre class="hljs"><code>npm install @webpods/tinqer-sql-better-sqlite3 better-sqlite3
+<pre class="hljs"><code>npm install @tinqerjs/better-sqlite3-adapter better-sqlite3
 </code></pre>
 <h3 id="22-setup-%26-query-execution" tabindex="-1"><a class="anchor" href="#22-setup-%26-query-execution" aria-hidden="true">#</a> 2.2 Setup &amp; Query Execution</h3>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> <span class="hljs-title class_">Database</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;better-sqlite3&quot;</span>;
-<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
 <span class="hljs-keyword">import</span> {
   executeSelect,
   executeInsert,
   executeUpdate,
   executeDelete,
   toSql,
-} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-better-sqlite3&quot;</span>;
+} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/better-sqlite3-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">email</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">isActive</span>: <span class="hljs-built_in">number</span> };
@@ -336,8 +336,8 @@ db.<span class="hljs-title function_">exec</span>(<span class="hljs-string">`
 </table>
 <h3 id="33-case-insensitive-matching" tabindex="-1"><a class="anchor" href="#33-case-insensitive-matching" aria-hidden="true">#</a> 3.3 Case-Insensitive Matching</h3>
 <p>Use query helpers for portable case-insensitive comparisons:</p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">email</span>: <span class="hljs-built_in">string</span> };

--- a/build/api-reference.html
+++ b/build/api-reference.html
@@ -84,14 +84,14 @@
 <h2 id="1-execution-apis" tabindex="-1"><a class="anchor" href="#1-execution-apis" aria-hidden="true">#</a> 1. Execution APIs</h2>
 <p>Tinqer uses a two-step API:</p>
 <ol>
-<li><strong>Plan definition</strong> (<code>define*</code> functions from <code>@webpods/tinqer</code>) - Creates type-safe query plans</li>
+<li><strong>Plan definition</strong> (<code>define*</code> functions from <code>@tinqerjs/tinqer</code>) - Creates type-safe query plans</li>
 <li><strong>Execution or SQL generation</strong> (<code>execute*</code> or <code>toSql</code> from adapter packages) - Executes plans or generates SQL</li>
 </ol>
-<p>Adapter packages live in <code>@webpods/tinqer-sql-pg-promise</code> (PostgreSQL) and <code>@webpods/tinqer-sql-better-sqlite3</code> (SQLite).</p>
+<p>Adapter packages live in <code>@tinqerjs/pg-promise-adapter</code> (PostgreSQL) and <code>@tinqerjs/better-sqlite3-adapter</code> (SQLite).</p>
 <h3 id="11-defineselect%2C-tosql-%26-executeselect" tabindex="-1"><a class="anchor" href="#11-defineselect%2C-tosql-%26-executeselect" aria-hidden="true">#</a> 1.1 defineSelect, toSql &amp; executeSelect</h3>
 <p>Creates SELECT query plans, generates SQL, or executes queries.</p>
 <p><strong>Signatures</strong></p>
-<pre class="hljs"><code><span class="hljs-comment">// Plan definition (from @webpods/tinqer)</span>
+<pre class="hljs"><code><span class="hljs-comment">// Plan definition (from @tinqerjs/tinqer)</span>
 <span class="hljs-keyword">function</span> defineSelect&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TResult</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
   <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
@@ -117,8 +117,8 @@
 ): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-title class_">TResult</span>[] | <span class="hljs-title class_">TResult</span>&gt;;
 </code></pre>
 <p><strong>Example - SQL Generation</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span> };
@@ -139,8 +139,8 @@
 <span class="hljs-comment">// params: { minAge: 18 }</span>
 </code></pre>
 <p><strong>Example - Execution</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span> };
@@ -163,7 +163,7 @@
 <h3 id="12-defineinsert%2C-tosql-%26-executeinsert" tabindex="-1"><a class="anchor" href="#12-defineinsert%2C-tosql-%26-executeinsert" aria-hidden="true">#</a> 1.2 defineInsert, toSql &amp; executeInsert</h3>
 <p>Creates INSERT query plans, generates SQL, or executes queries with optional RETURNING clauses.</p>
 <p><strong>Signatures</strong></p>
-<pre class="hljs"><code><span class="hljs-comment">// Plan definition (from @webpods/tinqer)</span>
+<pre class="hljs"><code><span class="hljs-comment">// Plan definition (from @tinqerjs/tinqer)</span>
 <span class="hljs-keyword">function</span> defineInsert&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span> = <span class="hljs-built_in">never</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
   <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
@@ -189,8 +189,8 @@
 ): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-title class_">TReturning</span> <span class="hljs-keyword">extends</span> <span class="hljs-built_in">never</span> ? <span class="hljs-built_in">number</span> : <span class="hljs-title class_">TReturning</span>[]&gt;;
 </code></pre>
 <p><strong>Example - SQL Generation</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span> };
@@ -208,8 +208,8 @@
 <span class="hljs-comment">// params: { name: &quot;Alice&quot; }</span>
 </code></pre>
 <p><strong>Example - Execution</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeInsert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeInsert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span> };
@@ -240,7 +240,7 @@
 <h3 id="13-defineupdate%2C-tosql-%26-executeupdate" tabindex="-1"><a class="anchor" href="#13-defineupdate%2C-tosql-%26-executeupdate" aria-hidden="true">#</a> 1.3 defineUpdate, toSql &amp; executeUpdate</h3>
 <p>Creates UPDATE query plans, generates SQL, or executes queries with optional RETURNING clauses.</p>
 <p><strong>Signatures</strong></p>
-<pre class="hljs"><code><span class="hljs-comment">// Plan definition (from @webpods/tinqer)</span>
+<pre class="hljs"><code><span class="hljs-comment">// Plan definition (from @tinqerjs/tinqer)</span>
 <span class="hljs-keyword">function</span> defineUpdate&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>, <span class="hljs-title class_">TTable</span>, <span class="hljs-title class_">TReturning</span> = <span class="hljs-built_in">never</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
   <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
@@ -269,8 +269,8 @@
 ): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-title class_">TReturning</span> <span class="hljs-keyword">extends</span> <span class="hljs-built_in">never</span> ? <span class="hljs-built_in">number</span> : <span class="hljs-title class_">TReturning</span>[]&gt;;
 </code></pre>
 <p><strong>Example - SQL Generation</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineUpdate } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineUpdate } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">status</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">lastLogin</span>: <span class="hljs-title class_">Date</span> };
@@ -291,8 +291,8 @@
 <span class="hljs-comment">// params: { cutoff: Date }</span>
 </code></pre>
 <p><strong>Example - Execution</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeUpdate } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeUpdate } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">lastLogin</span>: <span class="hljs-title class_">Date</span>; <span class="hljs-attr">status</span>: <span class="hljs-built_in">string</span> };
@@ -328,7 +328,7 @@
 <h3 id="14-definedelete%2C-tosql-%26-executedelete" tabindex="-1"><a class="anchor" href="#14-definedelete%2C-tosql-%26-executedelete" aria-hidden="true">#</a> 1.4 defineDelete, toSql &amp; executeDelete</h3>
 <p>Creates DELETE query plans, generates SQL, or executes queries.</p>
 <p><strong>Signatures</strong></p>
-<pre class="hljs"><code><span class="hljs-comment">// Plan definition (from @webpods/tinqer)</span>
+<pre class="hljs"><code><span class="hljs-comment">// Plan definition (from @tinqerjs/tinqer)</span>
 <span class="hljs-keyword">function</span> defineDelete&lt;<span class="hljs-title class_">TSchema</span>, <span class="hljs-title class_">TParams</span>&gt;(
   <span class="hljs-attr">schema</span>: <span class="hljs-title class_">DatabaseSchema</span>&lt;<span class="hljs-title class_">TSchema</span>&gt;,
   <span class="hljs-attr">queryBuilder</span>: <span class="hljs-function">(<span class="hljs-params">
@@ -354,8 +354,8 @@
 ): <span class="hljs-title class_">Promise</span>&lt;<span class="hljs-built_in">number</span>&gt;;
 </code></pre>
 <p><strong>Example - SQL Generation</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">status</span>: <span class="hljs-built_in">string</span> };
@@ -373,8 +373,8 @@
 <span class="hljs-comment">// params: { status: &quot;inactive&quot; }</span>
 </code></pre>
 <p><strong>Example - Execution</strong></p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">status</span>: <span class="hljs-built_in">string</span> };
@@ -406,8 +406,8 @@
 <h2 id="2-type-safe-contexts" tabindex="-1"><a class="anchor" href="#2-type-safe-contexts" aria-hidden="true">#</a> 2. Type-Safe Contexts</h2>
 <h3 id="21-createschema" tabindex="-1"><a class="anchor" href="#21-createschema" aria-hidden="true">#</a> 2.1 createSchema</h3>
 <p>Creates a phantom-typed <code>DatabaseSchema</code> that ties table names to row types. The schema is passed to execution functions, which provide a type-safe query builder through the lambda’s first parameter.</p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">email</span>: <span class="hljs-built_in">string</span> };
@@ -428,8 +428,8 @@
 <h2 id="3-helper-utilities" tabindex="-1"><a class="anchor" href="#3-helper-utilities" aria-hidden="true">#</a> 3. Helper Utilities</h2>
 <h3 id="31-createqueryhelpers" tabindex="-1"><a class="anchor" href="#31-createqueryhelpers" aria-hidden="true">#</a> 3.1 createQueryHelpers</h3>
 <p>Provides helper functions for case-insensitive comparisons and string searches. Helpers are automatically passed as the third parameter to query builder functions.</p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span> };

--- a/build/architecture.html
+++ b/build/architecture.html
@@ -60,8 +60,8 @@
 <h2 id="database-adapters" tabindex="-1"><a class="anchor" href="#database-adapters" aria-hidden="true">#</a> Database Adapters</h2>
 <p>The core package is adapter-agnostic; database-specific behavior lives in companion adapters. The repository currently ships two adapters:</p>
 <ul>
-<li><code>@webpods/tinqer-sql-pg-promise</code> – PostgreSQL integration built on pg-promise</li>
-<li><code>@webpods/tinqer-sql-better-sqlite3</code> – SQLite integration powered by better-sqlite3</li>
+<li><code>@tinqerjs/pg-promise-adapter</code> – PostgreSQL integration built on pg-promise</li>
+<li><code>@tinqerjs/better-sqlite3-adapter</code> – SQLite integration powered by better-sqlite3</li>
 </ul>
 <p>Both adapters provide execution functions (<code>executeSelect</code>, <code>executeInsert</code>, etc.) that accept plan handles created by <code>define*</code> functions from the core package. Query plans are created using <code>defineSelect</code>, <code>defineInsert</code>, <code>defineUpdate</code>, and <code>defineDelete</code>, which parse query builder lambdas. Plans can then be executed with adapter-specific <code>execute*</code> functions or converted to SQL using <code>toSql</code>, allowing database switching without rewriting query code.</p>
 <h2 id="core-design-principles" tabindex="-1"><a class="anchor" href="#core-design-principles" aria-hidden="true">#</a> Core Design Principles</h2>

--- a/build/development.html
+++ b/build/development.html
@@ -113,7 +113,7 @@
 </ul>
 <h3 id="12-installation" tabindex="-1"><a class="anchor" href="#12-installation" aria-hidden="true">#</a> 1.2 Installation</h3>
 <pre class="hljs"><code><span class="hljs-comment"># Clone the repository</span>
-git <span class="hljs-built_in">clone</span> https://github.com/webpods-org/tinqer.git
+git <span class="hljs-built_in">clone</span> https://github.com/tinqerjs-org/tinqer.git
 <span class="hljs-built_in">cd</span> tinqer
 
 <span class="hljs-comment"># Install dependencies</span>
@@ -134,14 +134,14 @@ npm install
 │   │   │   └── types/                   # TypeScript type definitions
 │   │   └── tests/                       # Core library tests
 │   │
-│   ├── tinqer-sql-pg-promise/           # PostgreSQL adapter
+│   ├── pg-promise-adapter/           # PostgreSQL adapter
 │   │   ├── src/
 │   │   │   ├── adapter.ts               # PostgreSQL SQL adapter
 │   │   │   ├── execute.ts               # Execution functions
 │   │   │   └── visitors/                # PostgreSQL-specific visitors
 │   │   └── tests/                       # Integration tests
 │   │
-│   ├── tinqer-sql-better-sqlite3/       # SQLite adapter
+│   ├── better-sqlite3-adapter/       # SQLite adapter
 │   │   ├── src/
 │   │   │   ├── adapter.ts               # SQLite SQL adapter
 │   │   │   ├── execute.ts               # Execution functions
@@ -213,8 +213,8 @@ npm <span class="hljs-built_in">test</span>
 </ul>
 <p><strong>Integration Tests</strong> (<code>packages/tinqer-sql-*/tests/</code>):</p>
 <ul>
-<li>PostgreSQL integration: <code>tinqer-sql-pg-promise-integration/tests/</code></li>
-<li>SQLite integration: <code>tinqer-sql-better-sqlite3-integration/tests/</code></li>
+<li>PostgreSQL integration: <code>pg-promise-adapter-integration/tests/</code></li>
+<li>SQLite integration: <code>better-sqlite3-adapter-integration/tests/</code></li>
 <li>Full end-to-end query execution tests</li>
 <li>Database-specific feature tests</li>
 </ul>
@@ -222,8 +222,8 @@ npm <span class="hljs-built_in">test</span>
 <p><strong>Unit Test Example:</strong></p>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> { describe, it } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;mocha&quot;</span>;
 <span class="hljs-keyword">import</span> { strict <span class="hljs-keyword">as</span> assert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;assert&quot;</span>;
-<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-title function_">describe</span>(<span class="hljs-string">&quot;SQL Generation&quot;</span>, <span class="hljs-function">() =&gt;</span> {
   <span class="hljs-title function_">it</span>(<span class="hljs-string">&quot;should generate SQL with WHERE clause&quot;</span>, <span class="hljs-function">() =&gt;</span> {
@@ -246,8 +246,8 @@ npm <span class="hljs-built_in">test</span>
 <p><strong>Integration Test Example:</strong></p>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> { describe, it, beforeEach } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;mocha&quot;</span>;
 <span class="hljs-keyword">import</span> { strict <span class="hljs-keyword">as</span> assert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;assert&quot;</span>;
-<span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 <span class="hljs-keyword">import</span> { db } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;./shared-db.js&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
@@ -275,7 +275,7 @@ npm <span class="hljs-built_in">test</span>
 });
 </code></pre>
 <p><strong>Test Database Setup:</strong></p>
-<p>PostgreSQL tests use shared connection (<code>packages/tinqer-sql-pg-promise-integration/tests/shared-db.ts</code>):</p>
+<p>PostgreSQL tests use shared connection (<code>packages/pg-promise-adapter-integration/tests/shared-db.ts</code>):</p>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> pgPromise <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;pg-promise&quot;</span>;
 
 <span class="hljs-keyword">const</span> pgp = <span class="hljs-title function_">pgPromise</span>();

--- a/build/guide.html
+++ b/build/guide.html
@@ -158,8 +158,8 @@
 <h2 id="1-filtering-operations" tabindex="-1"><a class="anchor" href="#1-filtering-operations" aria-hidden="true">#</a> 1. Filtering Operations</h2>
 <p>The <code>where</code> method applies predicates to filter query results. Multiple <code>where</code> calls are combined with AND logic.</p>
 <h3 id="11-basic-comparison" tabindex="-1"><a class="anchor" href="#11-basic-comparison" aria-hidden="true">#</a> 1.1 Basic Comparison</h3>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">email</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">active</span>: <span class="hljs-built_in">boolean</span> };
@@ -1360,8 +1360,8 @@
 <h3 id="141-insert-statements" tabindex="-1"><a class="anchor" href="#141-insert-statements" aria-hidden="true">#</a> 14.1 INSERT Statements</h3>
 <p>The <code>insertInto</code> function creates INSERT operations. Values are specified using direct object syntax (no lambda wrapping required).</p>
 <h4 id="basic-insert" tabindex="-1"><a class="anchor" href="#basic-insert" aria-hidden="true">#</a> Basic INSERT</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineInsert } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">email</span>: <span class="hljs-built_in">string</span> };
@@ -1451,8 +1451,8 @@
 <h3 id="142-update-statements" tabindex="-1"><a class="anchor" href="#142-update-statements" aria-hidden="true">#</a> 14.2 UPDATE Statements</h3>
 <p>The <code>update</code> function creates UPDATE operations. The <code>.set()</code> method uses direct object syntax (no lambda wrapping required).</p>
 <h4 id="basic-update" tabindex="-1"><a class="anchor" href="#basic-update" aria-hidden="true">#</a> Basic UPDATE</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineUpdate } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineUpdate } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
@@ -1532,8 +1532,8 @@ Full table updates are dangerous and must be explicitly allowed.
 <h3 id="143-delete-statements" tabindex="-1"><a class="anchor" href="#143-delete-statements" aria-hidden="true">#</a> 14.3 DELETE Statements</h3>
 <p>The <code>deleteFrom</code> function creates DELETE operations with optional WHERE conditions.</p>
 <h4 id="basic-delete" tabindex="-1"><a class="anchor" href="#basic-delete" aria-hidden="true">#</a> Basic DELETE</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
@@ -1650,8 +1650,8 @@ Full table updates are dangerous and must be explicitly allowed.
 <h3 id="145-executing-crud-operations" tabindex="-1"><a class="anchor" href="#145-executing-crud-operations" aria-hidden="true">#</a> 14.5 Executing CRUD Operations</h3>
 <p>The adapter packages provide execution functions for all CRUD operations:</p>
 <h4 id="postgresql-(pg-promise)" tabindex="-1"><a class="anchor" href="#postgresql-(pg-promise)" aria-hidden="true">#</a> PostgreSQL (pg-promise)</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
@@ -1690,8 +1690,8 @@ Full table updates are dangerous and must be explicitly allowed.
 );
 </code></pre>
 <h4 id="sqlite-(better-sqlite3)" tabindex="-1"><a class="anchor" href="#sqlite-(better-sqlite3)" aria-hidden="true">#</a> SQLite (better-sqlite3)</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-better-sqlite3&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/better-sqlite3-adapter&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
@@ -1779,8 +1779,8 @@ Full table updates are dangerous and must be explicitly allowed.
 <p>Tinqer query plans are <strong>immutable and composable</strong>. Plan handles returned by <code>define*</code> functions support method chaining - each operation returns a new plan without modifying the original. This enables powerful query composition patterns: reusable base queries, branching specialized variations, and parameter accumulation.</p>
 <h3 id="151-chaining-operations-on-plans" tabindex="-1"><a class="anchor" href="#151-chaining-operations-on-plans" aria-hidden="true">#</a> 15.1 Chaining Operations on Plans</h3>
 <p>All plan handles support chaining operations like <code>where()</code>, <code>orderBy()</code>, <code>select()</code>, etc.:</p>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema, defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">isActive</span>: <span class="hljs-built_in">boolean</span> };

--- a/build/index.html
+++ b/build/index.html
@@ -60,18 +60,18 @@
 <h2 id="installation" tabindex="-1"><a class="anchor" href="#installation" aria-hidden="true">#</a> Installation</h2>
 <p>Install the core library and adapter for your database:</p>
 <pre class="hljs"><code><span class="hljs-comment"># Core library</span>
-npm install @webpods/tinqer
+npm install @tinqerjs/tinqer
 
 <span class="hljs-comment"># PostgreSQL adapter (pg-promise)</span>
-npm install @webpods/tinqer-sql-pg-promise
+npm install @tinqerjs/pg-promise-adapter
 
 <span class="hljs-comment"># SQLite adapter (better-sqlite3)</span>
-npm install @webpods/tinqer-sql-better-sqlite3
+npm install @tinqerjs/better-sqlite3-adapter
 </code></pre>
 <h2 id="quick-start" tabindex="-1"><a class="anchor" href="#quick-start" aria-hidden="true">#</a> Quick Start</h2>
 <h3 id="postgresql-example" tabindex="-1"><a class="anchor" href="#postgresql-example" aria-hidden="true">#</a> PostgreSQL Example</h3>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 <span class="hljs-keyword">import</span> pgPromise <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;pg-promise&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -102,8 +102,8 @@ npm install @webpods/tinqer-sql-better-sqlite3
 </code></pre>
 <p><strong>The same query works with SQLite</strong> - just change the adapter and database connection:</p>
 <pre class="hljs"><code><span class="hljs-keyword">import</span> <span class="hljs-title class_">Database</span> <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;better-sqlite3&quot;</span>;
-<span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-better-sqlite3&quot;</span>;
+<span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/better-sqlite3-adapter&quot;</span>;
 
 <span class="hljs-comment">// Same schema definition</span>
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
@@ -140,8 +140,8 @@ npm install @webpods/tinqer-sql-better-sqlite3
   defineInsert,
   defineUpdate,
   defineDelete,
-} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+} <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">interface</span> <span class="hljs-title class_">Schema</span> {
   <span class="hljs-attr">users</span>: { <span class="hljs-attr">id</span>: <span class="hljs-built_in">number</span>; <span class="hljs-attr">name</span>: <span class="hljs-built_in">string</span>; <span class="hljs-attr">age</span>: <span class="hljs-built_in">number</span> };
@@ -207,8 +207,8 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <h3 id="query-composition" tabindex="-1"><a class="anchor" href="#query-composition" aria-hidden="true">#</a> Query Composition</h3>
 <p>Query plans are <strong>immutable and composable</strong> - you can chain operations onto plan handles to create reusable base queries and branch into specialized variations.</p>
 <h4 id="chaining-operations-on-plans" tabindex="-1"><a class="anchor" href="#chaining-operations-on-plans" aria-hidden="true">#</a> Chaining Operations on Plans</h4>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { defineSelect } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { toSql } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
@@ -361,8 +361,8 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <p><strong>Automatic Subquery Wrapping</strong>: Tinqer automatically detects when <code>where()</code> clauses reference window function columns and wraps the query in a subquery, since SQL doesn’t allow filtering on window functions at the same level where they’re defined.</p>
 <p>See the <a href="docs/guide.md#8-window-functions">Window Functions Guide</a> for detailed examples of <code>RANK()</code>, <code>DENSE_RANK()</code>, complex ordering, and <a href="docs/guide.md#85-filtering-on-window-function-results">filtering on window results</a>.</p>
 <h3 id="crud-operations" tabindex="-1"><a class="anchor" href="#crud-operations" aria-hidden="true">#</a> CRUD Operations</h3>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
-<span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer-sql-pg-promise&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
+<span class="hljs-keyword">import</span> { executeInsert, executeUpdate, executeDelete } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/pg-promise-adapter&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
@@ -425,7 +425,7 @@ npm install @webpods/tinqer-sql-better-sqlite3
 <span class="hljs-comment">// params: { __p1: 18 }</span>
 </code></pre>
 <h3 id="case-insensitive-string-operations" tabindex="-1"><a class="anchor" href="#case-insensitive-string-operations" aria-hidden="true">#</a> Case-Insensitive String Operations</h3>
-<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@webpods/tinqer&quot;</span>;
+<pre class="hljs"><code><span class="hljs-keyword">import</span> { createSchema } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;@tinqerjs/tinqer&quot;</span>;
 
 <span class="hljs-keyword">const</span> schema = createSchema&lt;<span class="hljs-title class_">Schema</span>&gt;();
 
@@ -498,15 +498,15 @@ npm install @webpods/tinqer-sql-better-sqlite3
 </thead>
 <tbody>
 <tr>
-<td><code>@webpods/tinqer</code></td>
+<td><code>@tinqerjs/tinqer</code></td>
 <td>Core expression tree and types (re-exported by adapters)</td>
 </tr>
 <tr>
-<td><code>@webpods/tinqer-sql-pg-promise</code></td>
+<td><code>@tinqerjs/pg-promise-adapter</code></td>
 <td>PostgreSQL adapter with pg-promise</td>
 </tr>
 <tr>
-<td><code>@webpods/tinqer-sql-better-sqlite3</code></td>
+<td><code>@tinqerjs/better-sqlite3-adapter</code></td>
 <td>SQLite adapter with better-sqlite3</td>
 </tr>
 </tbody>

--- a/build/llms.txt
+++ b/build/llms.txt
@@ -16,13 +16,13 @@ Install the core library and adapter for your database:
 
 ```bash
 # Core library
-npm install @webpods/tinqer
+npm install @tinqerjs/tinqer
 
 # PostgreSQL adapter (pg-promise)
-npm install @webpods/tinqer-sql-pg-promise
+npm install @tinqerjs/pg-promise-adapter
 
 # SQLite adapter (better-sqlite3)
-npm install @webpods/tinqer-sql-better-sqlite3
+npm install @tinqerjs/better-sqlite3-adapter
 ```
 
 ## Quick Start
@@ -30,8 +30,8 @@ npm install @webpods/tinqer-sql-better-sqlite3
 ### PostgreSQL Example
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
-import { executeSelect } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema } from "@tinqerjs/tinqer";
+import { executeSelect } from "@tinqerjs/pg-promise-adapter";
 import pgPromise from "pg-promise";
 
 interface Schema {
@@ -65,8 +65,8 @@ const results = await executeSelect(
 
 ```typescript
 import Database from "better-sqlite3";
-import { createSchema } from "@webpods/tinqer";
-import { executeSelect } from "@webpods/tinqer-sql-better-sqlite3";
+import { createSchema } from "@tinqerjs/tinqer";
+import { executeSelect } from "@tinqerjs/better-sqlite3-adapter";
 
 // Same schema definition
 interface Schema {
@@ -107,8 +107,8 @@ import {
   defineInsert,
   defineUpdate,
   defineDelete,
-} from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+} from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; age: number };
@@ -183,8 +183,8 @@ Query plans are **immutable and composable** - you can chain operations onto pla
 #### Chaining Operations on Plans
 
 ```typescript
-import { defineSelect } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { defineSelect } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 const schema = createSchema<Schema>();
 
@@ -235,8 +235,7 @@ type ChainParams = { maxAge: number };
 
 const plan = defineSelect(schema, (q, p: BuilderParams) =>
   q.from("users").where((u) => u.age > p.baseAge),
-)
-.where<ChainParams>((u, p) => u.age < p.maxAge);
+).where<ChainParams>((u, p) => u.age < p.maxAge);
 
 // Must provide both parameter types
 toSql(plan, { baseAge: 18, maxAge: 65 });
@@ -371,8 +370,8 @@ See the [Window Functions Guide](docs/guide.md#8-window-functions) for detailed 
 ### CRUD Operations
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
-import { executeInsert, executeUpdate, executeDelete } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema } from "@tinqerjs/tinqer";
+import { executeInsert, executeUpdate, executeDelete } from "@tinqerjs/pg-promise-adapter";
 
 const schema = createSchema<Schema>();
 
@@ -442,7 +441,7 @@ const literals = toSql(
 ### Case-Insensitive String Operations
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
+import { createSchema } from "@tinqerjs/tinqer";
 
 const schema = createSchema<Schema>();
 
@@ -512,11 +511,11 @@ See [Database Adapters](docs/adapters.md) for detailed comparison.
 
 ## Packages
 
-| Package                              | Purpose                                                  |
-| ------------------------------------ | -------------------------------------------------------- |
-| `@webpods/tinqer`                    | Core expression tree and types (re-exported by adapters) |
-| `@webpods/tinqer-sql-pg-promise`     | PostgreSQL adapter with pg-promise                       |
-| `@webpods/tinqer-sql-better-sqlite3` | SQLite adapter with better-sqlite3                       |
+| Package                            | Purpose                                                  |
+| ---------------------------------- | -------------------------------------------------------- |
+| `@tinqerjs/tinqer`                 | Core expression tree and types (re-exported by adapters) |
+| `@tinqerjs/pg-promise-adapter`     | PostgreSQL adapter with pg-promise                       |
+| `@tinqerjs/better-sqlite3-adapter` | SQLite adapter with better-sqlite3                       |
 
 ## Credits
 
@@ -537,7 +536,7 @@ MIT
 
 # Database Adapters
 
-Tinqer ships dedicated adapters for PostgreSQL (`@webpods/tinqer-sql-pg-promise`) and SQLite (`@webpods/tinqer-sql-better-sqlite3`). Both share the same builder APIs while handling dialect-specific SQL generation and parameter formatting.
+Tinqer ships dedicated adapters for PostgreSQL (`@tinqerjs/pg-promise-adapter`) and SQLite (`@tinqerjs/better-sqlite3-adapter`). Both share the same builder APIs while handling dialect-specific SQL generation and parameter formatting.
 
 ## Table of Contents
 
@@ -562,21 +561,21 @@ Tinqer ships dedicated adapters for PostgreSQL (`@webpods/tinqer-sql-pg-promise`
 ### 1.1 Installation
 
 ```bash
-npm install @webpods/tinqer-sql-pg-promise pg-promise
+npm install @tinqerjs/pg-promise-adapter pg-promise
 ```
 
 ### 1.2 Setup & Query Execution
 
 ```typescript
 import pgPromise from "pg-promise";
-import { createSchema, defineSelect } from "@webpods/tinqer";
+import { createSchema, defineSelect } from "@tinqerjs/tinqer";
 import {
   executeSelect,
   executeInsert,
   executeUpdate,
   executeDelete,
   toSql,
-} from "@webpods/tinqer-sql-pg-promise";
+} from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; email: string; age: number; active: boolean };
@@ -664,21 +663,21 @@ const { sql, params } = toSql(
 ### 2.1 Installation
 
 ```bash
-npm install @webpods/tinqer-sql-better-sqlite3 better-sqlite3
+npm install @tinqerjs/better-sqlite3-adapter better-sqlite3
 ```
 
 ### 2.2 Setup & Query Execution
 
 ```typescript
 import Database from "better-sqlite3";
-import { createSchema, defineSelect } from "@webpods/tinqer";
+import { createSchema, defineSelect } from "@tinqerjs/tinqer";
 import {
   executeSelect,
   executeInsert,
   executeUpdate,
   executeDelete,
   toSql,
-} from "@webpods/tinqer-sql-better-sqlite3";
+} from "@tinqerjs/better-sqlite3-adapter";
 
 interface Schema {
   users: { id: number; name: string; email: string; age: number; isActive: number };
@@ -776,8 +775,8 @@ const rows = db.prepare(sql).all(params);
 Use query helpers for portable case-insensitive comparisons:
 
 ```typescript
-import { createSchema, defineSelect } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineSelect } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; email: string };
@@ -828,10 +827,10 @@ Reference for adapter execution helpers, typed contexts, and query utilities.
 
 Tinqer uses a two-step API:
 
-1. **Plan definition** (`define*` functions from `@webpods/tinqer`) - Creates type-safe query plans
+1. **Plan definition** (`define*` functions from `@tinqerjs/tinqer`) - Creates type-safe query plans
 2. **Execution or SQL generation** (`execute*` or `toSql` from adapter packages) - Executes plans or generates SQL
 
-Adapter packages live in `@webpods/tinqer-sql-pg-promise` (PostgreSQL) and `@webpods/tinqer-sql-better-sqlite3` (SQLite).
+Adapter packages live in `@tinqerjs/pg-promise-adapter` (PostgreSQL) and `@tinqerjs/better-sqlite3-adapter` (SQLite).
 
 ### 1.1 defineSelect, toSql & executeSelect
 
@@ -840,7 +839,7 @@ Creates SELECT query plans, generates SQL, or executes queries.
 **Signatures**
 
 ```typescript
-// Plan definition (from @webpods/tinqer)
+// Plan definition (from @tinqerjs/tinqer)
 function defineSelect<TSchema, TParams, TResult>(
   schema: DatabaseSchema<TSchema>,
   queryBuilder: (
@@ -869,8 +868,8 @@ async function executeSelect<TResult, TParams>(
 **Example - SQL Generation**
 
 ```typescript
-import { createSchema, defineSelect } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineSelect } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; age: number };
@@ -894,8 +893,8 @@ const { sql, params } = toSql(
 **Example - Execution**
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
-import { executeSelect } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema } from "@tinqerjs/tinqer";
+import { executeSelect } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; age: number };
@@ -923,7 +922,7 @@ Creates INSERT query plans, generates SQL, or executes queries with optional RET
 **Signatures**
 
 ```typescript
-// Plan definition (from @webpods/tinqer)
+// Plan definition (from @tinqerjs/tinqer)
 function defineInsert<TSchema, TParams, TTable, TReturning = never>(
   schema: DatabaseSchema<TSchema>,
   queryBuilder: (
@@ -952,8 +951,8 @@ async function executeInsert<TTable, TReturning, TParams>(
 **Example - SQL Generation**
 
 ```typescript
-import { createSchema, defineInsert } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineInsert } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string };
@@ -974,8 +973,8 @@ const { sql, params } = toSql(
 **Example - Execution**
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
-import { executeInsert } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema } from "@tinqerjs/tinqer";
+import { executeInsert } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string };
@@ -1011,7 +1010,7 @@ Creates UPDATE query plans, generates SQL, or executes queries with optional RET
 **Signatures**
 
 ```typescript
-// Plan definition (from @webpods/tinqer)
+// Plan definition (from @tinqerjs/tinqer)
 function defineUpdate<TSchema, TParams, TTable, TReturning = never>(
   schema: DatabaseSchema<TSchema>,
   queryBuilder: (
@@ -1043,8 +1042,8 @@ async function executeUpdate<TTable, TReturning, TParams>(
 **Example - SQL Generation**
 
 ```typescript
-import { createSchema, defineUpdate } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineUpdate } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; status: string; lastLogin: Date };
@@ -1068,8 +1067,8 @@ const { sql, params } = toSql(
 **Example - Execution**
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
-import { executeUpdate } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema } from "@tinqerjs/tinqer";
+import { executeUpdate } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; lastLogin: Date; status: string };
@@ -1110,7 +1109,7 @@ Creates DELETE query plans, generates SQL, or executes queries.
 **Signatures**
 
 ```typescript
-// Plan definition (from @webpods/tinqer)
+// Plan definition (from @tinqerjs/tinqer)
 function defineDelete<TSchema, TParams>(
   schema: DatabaseSchema<TSchema>,
   queryBuilder: (
@@ -1139,8 +1138,8 @@ async function executeDelete<TParams>(
 **Example - SQL Generation**
 
 ```typescript
-import { createSchema, defineDelete } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineDelete } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; status: string };
@@ -1161,8 +1160,8 @@ const { sql, params } = toSql(
 **Example - Execution**
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
-import { executeDelete } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema } from "@tinqerjs/tinqer";
+import { executeDelete } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; status: string };
@@ -1205,8 +1204,8 @@ Use `onSql` for logging, testing, or debugging without changing execution flow.
 Creates a phantom-typed `DatabaseSchema` that ties table names to row types. The schema is passed to execution functions, which provide a type-safe query builder through the lambda's first parameter.
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
-import { executeSelect } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema } from "@tinqerjs/tinqer";
+import { executeSelect } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; email: string };
@@ -1233,8 +1232,8 @@ const results = await executeSelect(
 Provides helper functions for case-insensitive comparisons and string searches. Helpers are automatically passed as the third parameter to query builder functions.
 
 ```typescript
-import { createSchema, defineSelect } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineSelect } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string };
@@ -1321,7 +1320,7 @@ Guide for contributing to Tinqer, running tests, and troubleshooting.
 
 ```bash
 # Clone the repository
-git clone https://github.com/webpods-org/tinqer.git
+git clone https://github.com/tinqerjs-org/tinqer.git
 cd tinqer
 
 # Install dependencies
@@ -1345,14 +1344,14 @@ tinqer/
 │   │   │   └── types/                   # TypeScript type definitions
 │   │   └── tests/                       # Core library tests
 │   │
-│   ├── tinqer-sql-pg-promise/           # PostgreSQL adapter
+│   ├── pg-promise-adapter/           # PostgreSQL adapter
 │   │   ├── src/
 │   │   │   ├── adapter.ts               # PostgreSQL SQL adapter
 │   │   │   ├── execute.ts               # Execution functions
 │   │   │   └── visitors/                # PostgreSQL-specific visitors
 │   │   └── tests/                       # Integration tests
 │   │
-│   ├── tinqer-sql-better-sqlite3/       # SQLite adapter
+│   ├── better-sqlite3-adapter/       # SQLite adapter
 │   │   ├── src/
 │   │   │   ├── adapter.ts               # SQLite SQL adapter
 │   │   │   ├── execute.ts               # Execution functions
@@ -1439,8 +1438,8 @@ npm test
 
 **Integration Tests** (`packages/tinqer-sql-*/tests/`):
 
-- PostgreSQL integration: `tinqer-sql-pg-promise-integration/tests/`
-- SQLite integration: `tinqer-sql-better-sqlite3-integration/tests/`
+- PostgreSQL integration: `pg-promise-adapter-integration/tests/`
+- SQLite integration: `better-sqlite3-adapter-integration/tests/`
 - Full end-to-end query execution tests
 - Database-specific feature tests
 
@@ -1451,8 +1450,8 @@ npm test
 ```typescript
 import { describe, it } from "mocha";
 import { strict as assert } from "assert";
-import { createSchema, defineSelect } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineSelect } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 describe("SQL Generation", () => {
   it("should generate SQL with WHERE clause", () => {
@@ -1478,8 +1477,8 @@ describe("SQL Generation", () => {
 ```typescript
 import { describe, it, beforeEach } from "mocha";
 import { strict as assert } from "assert";
-import { createSchema } from "@webpods/tinqer";
-import { executeSelect } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema } from "@tinqerjs/tinqer";
+import { executeSelect } from "@tinqerjs/pg-promise-adapter";
 import { db } from "./shared-db.js";
 
 const schema = createSchema<Schema>();
@@ -1509,7 +1508,7 @@ describe("PostgreSQL Integration", () => {
 
 **Test Database Setup:**
 
-PostgreSQL tests use shared connection (`packages/tinqer-sql-pg-promise-integration/tests/shared-db.ts`):
+PostgreSQL tests use shared connection (`packages/pg-promise-adapter-integration/tests/shared-db.ts`):
 
 ```typescript
 import pgPromise from "pg-promise";
@@ -1939,8 +1938,8 @@ The `where` method applies predicates to filter query results. Multiple `where` 
 ### 1.1 Basic Comparison
 
 ```typescript
-import { createSchema, defineSelect } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineSelect } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; age: number; email: string; active: boolean };
@@ -3505,8 +3504,8 @@ The `insertInto` function creates INSERT operations. Values are specified using 
 #### Basic INSERT
 
 ```typescript
-import { createSchema, defineInsert } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineInsert } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; age: number; email: string };
@@ -3617,8 +3616,8 @@ The `update` function creates UPDATE operations. The `.set()` method uses direct
 #### Basic UPDATE
 
 ```typescript
-import { createSchema, defineUpdate } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineUpdate } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 const schema = createSchema<Schema>();
 
@@ -3721,8 +3720,8 @@ The `deleteFrom` function creates DELETE operations with optional WHERE conditio
 #### Basic DELETE
 
 ```typescript
-import { createSchema, defineDelete } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineDelete } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 const schema = createSchema<Schema>();
 
@@ -3875,8 +3874,8 @@ The adapter packages provide execution functions for all CRUD operations:
 #### PostgreSQL (pg-promise)
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
-import { executeInsert, executeUpdate, executeDelete } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema } from "@tinqerjs/tinqer";
+import { executeInsert, executeUpdate, executeDelete } from "@tinqerjs/pg-promise-adapter";
 
 const schema = createSchema<Schema>();
 
@@ -3918,8 +3917,8 @@ const deleteCount = await executeDelete(
 #### SQLite (better-sqlite3)
 
 ```typescript
-import { createSchema } from "@webpods/tinqer";
-import { executeInsert, executeUpdate, executeDelete } from "@webpods/tinqer-sql-better-sqlite3";
+import { createSchema } from "@tinqerjs/tinqer";
+import { executeInsert, executeUpdate, executeDelete } from "@tinqerjs/better-sqlite3-adapter";
 
 const schema = createSchema<Schema>();
 
@@ -4019,8 +4018,8 @@ Tinqer query plans are **immutable and composable**. Plan handles returned by `d
 All plan handles support chaining operations like `where()`, `orderBy()`, `select()`, etc.:
 
 ```typescript
-import { createSchema, defineSelect } from "@webpods/tinqer";
-import { toSql } from "@webpods/tinqer-sql-pg-promise";
+import { createSchema, defineSelect } from "@tinqerjs/tinqer";
+import { toSql } from "@tinqerjs/pg-promise-adapter";
 
 interface Schema {
   users: { id: number; name: string; age: number; isActive: boolean };
@@ -4259,9 +4258,7 @@ function paginate<TPlan extends { skip: Function; take: Function }>(
   return plan.skip((page - 1) * pageSize).take(pageSize) as TPlan;
 }
 
-const allArticles = defineSelect(schema, (q) =>
-  q.from("articles").orderBy((a) => a.createdAt),
-);
+const allArticles = defineSelect(schema, (q) => q.from("articles").orderBy((a) => a.createdAt));
 
 // Page 1
 const page1 = paginate(allArticles, 1, 20);


### PR DESCRIPTION
- Update package references from tinqer-sql-* to adapter naming
- Reflect version bump to 0.0.22
- Regenerate all documentation pages and llms.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)