### PR TITLE
docs: rebuild site with updated terminology

### DIFF
--- a/build/architecture.html
+++ b/build/architecture.html
@@ -56,7 +56,7 @@
     <div class="content-wrapper">
       <article class="markdown-body">
         <h1 id="architecture" tabindex="-1"><a class="anchor" href="#architecture" aria-hidden="true">#</a> Architecture</h1>
-<p>Tinqer is a LINQ-to-SQL query builder for TypeScript that converts lambda expressions into SQL queries through runtime parsing and expression tree generation.</p>
+<p>Tinqer is a type-safe query builder (for TypeScript) that converts lambda expressions into SQL queries through runtime parsing and expression tree generation. The API is similar to DotNet’s LINQ-based frameworks.</p>
 <h2 id="database-adapters" tabindex="-1"><a class="anchor" href="#database-adapters" aria-hidden="true">#</a> Database Adapters</h2>
 <p>The core package is adapter-agnostic; database-specific behavior lives in companion adapters. The repository currently ships two adapters:</p>
 <ul>

--- a/build/index.html
+++ b/build/index.html
@@ -56,7 +56,7 @@
     <div class="content-wrapper">
       <article class="markdown-body">
         <h1 id="tinqer" tabindex="-1"><a class="anchor" href="#tinqer" aria-hidden="true">#</a> Tinqer</h1>
-<p>Runtime LINQ-to-SQL query builder for TypeScript. Queries are expressed as inline arrow functions, parsed into an expression tree, and compiled into SQL for PostgreSQL or SQLite.</p>
+<p>A type-safe query builder for TypeScript. Queries are expressed as inline arrow functions, parsed into an expression tree, and compiled into SQL for PostgreSQL or SQLite. The API is similar to DotNet’s LINQ-based frameworks.</p>
 <h2 id="installation" tabindex="-1"><a class="anchor" href="#installation" aria-hidden="true">#</a> Installation</h2>
 <p>Install the core library and adapter for your database:</p>
 <pre class="hljs"><code><span class="hljs-comment"># Core library</span>

--- a/build/llms.txt
+++ b/build/llms.txt
@@ -1,14 +1,13 @@
 # Tinqer Documentation
 
-This file contains the complete documentation for Tinqer, a runtime LINQ-to-SQL query builder for TypeScript.
-
+This file contains the complete documentation for Tinqer, a type-safe query builder for TypeScript.
 ---
 
 ## README
 
 # Tinqer
 
-Runtime LINQ-to-SQL query builder for TypeScript. Queries are expressed as inline arrow functions, parsed into an expression tree, and compiled into SQL for PostgreSQL or SQLite.
+A type-safe query builder for TypeScript. Queries are expressed as inline arrow functions, parsed into an expression tree, and compiled into SQL for PostgreSQL or SQLite. The API is similar to DotNet's LINQ-based frameworks.
 
 ## Installation
 


### PR DESCRIPTION
Regenerated documentation site to reflect updated terminology from LINQ-to-SQL to type-safe query builder. Content is sourced from the tinqer repository which was updated in the previous commit.

Changes:
- build/index.html: Updated main description
- build/architecture.html: Updated architecture description
- build/llms.txt: Regenerated with updated terminology

🤖 Generated with [Claude Code](https://claude.com/claude-code)